### PR TITLE
Add more config options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 
 /*
 
+# Linux temporary files
+
+/*~
+
 # Except the stuff i want to keep
 
 # Gradle Stuff
@@ -23,3 +27,4 @@
 
 # Other Important Folders
 !src/
+

--- a/build.properties
+++ b/build.properties
@@ -2,8 +2,9 @@ minecraft_version=1.7.10
 mod_version=1.0.2e
 forge_version=10.13.4.1614-1.7.10
 CCLIB_version=1.1.3.140
-NEI_version=1.0.3.74
-ccc_version=1.0.4.29
+NEI_version=1.0.5.120
+ccc_version=1.0.7.47
 
 
 //Version System A.B.CD A=Minecraft version (increments with each new minecraft version) B=Major mod change (May break saves) C=Release Number (Increments with each public release) D=Bugfix version (a-z)
+

--- a/gradlew
+++ b/gradlew
@@ -42,6 +42,11 @@ case "`uname`" in
     ;;
 esac
 
+# For Cygwin, ensure paths are in UNIX format before anything is touched.
+if $cygwin ; then
+    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+fi
+
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link
 PRG="$0"
@@ -109,7 +114,6 @@ fi
 if $cygwin ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
-    JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath
     ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIUpgradeModifier.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIUpgradeModifier.java
@@ -1,5 +1,8 @@
 package com.brandon3055.draconicevolution.client.gui;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.brandon3055.brandonscore.client.utills.GuiHelper;
 import com.brandon3055.draconicevolution.client.handler.ResourceHandler;
 import com.brandon3055.draconicevolution.common.ModItems;
@@ -19,9 +22,6 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import org.lwjgl.opengl.GL11;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @SideOnly(Side.CLIENT)
 public class GUIUpgradeModifier extends GuiContainer {
@@ -159,13 +159,12 @@ public class GUIUpgradeModifier extends GuiContainer {
 			int xPos = guiLeft + (xIndex * spacing) + ((spacing - 23) / 2) + 4;
 			int yPos = guiTop + 90;
 
-
 			int[] appliedCores = upgrade.getCoresApplied(tile.getStackInSlot(0));
 
 			for (int i = 0; i <= coreTier; i++)
 			{
 				//Check + buttons
-				if (coreInInventory[i] && coreSlots > usedSlots && GuiHelper.isInRect(xPos, yPos+33 + i*18, 8, 8, x, y) && upgrade.getUpgradePoints(stack) < upgradableItem.getMaxUpgradePoints(upgrade.index)){
+				if (coreInInventory[i] && coreSlots > usedSlots && GuiHelper.isInRect(xPos, yPos+33 + i*18, 8, 8, x, y) && upgrade.getUpgradePoints(stack) < upgradableItem.getMaxUpgradePoints(upgrade.index, stack)){
 					containerEM.sendObjectToServer(null, upgrade.index, i*2);
 					Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(ResourceHandler.getResourceWOP("gui.button.press"), 1.0F));
 				}
@@ -209,7 +208,7 @@ public class GUIUpgradeModifier extends GuiContainer {
 				GL11.glDisable(GL11.GL_BLEND);
 
 				//Draw + buttons
-				if (coreSlots > usedSlots && upgrade.getUpgradePoints(stack) < upgradableItem.getMaxUpgradePoints(upgrade.index)){
+				if (coreSlots > usedSlots && upgrade.getUpgradePoints(stack) < upgradableItem.getMaxUpgradePoints(upgrade.index, stack)){
 					boolean hovering = GuiHelper.isInRect(xPos, yPos+33 + i*18, 8, 8, x, y);
 					if (!coreInInventory[i]) drawTexturedModalRect(xPos, yPos+33 + i*18, 24, 208, 8, 8);
 					else drawTexturedModalRect(xPos, yPos+33 + i*18, 32 + (hovering ? 8 : 0), 208, 8, 8);
@@ -260,7 +259,7 @@ public class GUIUpgradeModifier extends GuiContainer {
 			if (GuiHelper.isInRect(xPos+3, yPos-9, 18, 8, x, y)){
 				List list = new ArrayList();
 				list.add(StatCollector.translateToLocal("gui.de.basePoints.txt")+": "+upgradableItem.getBaseUpgradePoints(upgrade.index));
-				list.add(StatCollector.translateToLocal("gui.de.maxPoints.txt")+": "+upgradableItem.getMaxUpgradePoints(upgrade.index));
+				list.add(StatCollector.translateToLocal("gui.de.maxPoints.txt")+": "+upgradableItem.getMaxUpgradePoints(upgrade.index, stack));
 				list.add(StatCollector.translateToLocal("gui.de.pointCost.txt")+": "+upgrade.pointConversion);
 				drawHoveringText(list, x, y, fontRendererObj);
 			}

--- a/src/main/java/com/brandon3055/draconicevolution/common/CommonProxy.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/CommonProxy.java
@@ -87,7 +87,6 @@ public class CommonProxy {
 	}
 
 	public void init(FMLInitializationEvent event) {
-		BalanceConfigHandler.finishLoading();
 		CraftingHandler.init();
 		registerGuiHandeler();
 		registerWorldGen();
@@ -102,6 +101,7 @@ public class CommonProxy {
 	}
 
 	public void postInit(FMLPostInitializationEvent event) {
+		BalanceConfigHandler.finishLoading();
 		OreDoublingRegistry.init();
 		Achievements.registerAchievementPane();
 		LogHelper.info("Finished PostInitialization");

--- a/src/main/java/com/brandon3055/draconicevolution/common/CommonProxy.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/CommonProxy.java
@@ -48,6 +48,7 @@ public class CommonProxy {
 
 	public void preInit(FMLPreInitializationEvent event) {
 		ConfigHandler.init(event.getSuggestedConfigurationFile());
+		BalanceConfigHandler.init(event.getModConfigurationDirectory());
 		registerEventListeners(event.getSide());
 		ModBlocks.init();
 		ModItems.init();

--- a/src/main/java/com/brandon3055/draconicevolution/common/CommonProxy.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/CommonProxy.java
@@ -87,6 +87,7 @@ public class CommonProxy {
 	}
 
 	public void init(FMLInitializationEvent event) {
+		BalanceConfigHandler.finishLoading();
 		CraftingHandler.init();
 		registerGuiHandeler();
 		registerWorldGen();

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/itemblocks/DraconiumItemBlock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/itemblocks/DraconiumItemBlock.java
@@ -1,6 +1,9 @@
 package com.brandon3055.draconicevolution.common.blocks.itemblocks;
 
+import java.util.List;
+
 import cofh.api.energy.IEnergyContainerItem;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
@@ -13,8 +16,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
-import java.util.List;
-
 /**
  * Created by Brandon on 8/08/2014.
  */
@@ -24,9 +25,9 @@ public class DraconiumItemBlock extends ItemBlock implements IEnergyContainerIte
 		setHasSubtypes(true);
 	}
 
-	protected int capacity = 100000000;
-	protected int maxReceive = 10000000;
-	protected int maxExtract = 10000000;
+	protected int capacity = BalanceConfigHandler.draconiumBlockEnergyToChange;
+	protected int maxReceive = BalanceConfigHandler.draconiumBlockChargingSpeed;
+	protected int maxExtract = BalanceConfigHandler.draconiumBlockChargingSpeed;
 
 	@SuppressWarnings("unchecked")
 	@Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
@@ -1,9 +1,14 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.blocks.BlockDE;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
 import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.TileEnergyPylon;
@@ -26,10 +31,6 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
 
 /**
  * Created by Brandon on 25/07/2014.
@@ -84,11 +85,19 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
 		if (meta == 0)
 			return Item.getItemFromBlock(ModBlocks.draconiumBlock);
 		else if (meta == 1)
-			return Item.getItemFromBlock(Blocks.redstone_block);
+			return Item.getItemFromBlock(BalanceConfigHandler.energyStorageStructureBlock);
 		else
 			return null;
 	}
-
+	@Override
+	public int damageDropped(int metadata)
+	{
+		if (metadata == 1)
+		{
+			return BalanceConfigHandler.energyStorageStructureBlockMetadata;
+		}
+		return super.damageDropped(metadata);
+	}
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_) {
 		int meta = world.getBlockMetadata(x, y, z);
@@ -149,7 +158,7 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
 		if (meta == 0)
 			world.setBlock(x, y, z, ModBlocks.draconiumBlock);
 		else if (meta == 1)
-			world.setBlock(x, y, z, Blocks.redstone_block);
+			world.setBlock(x, y, z, BalanceConfigHandler.energyStorageStructureBlock, BalanceConfigHandler.energyStorageStructureBlockMetadata, 3);
 	}
 
 	@Override
@@ -179,10 +188,10 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
 		}
 		return super.getSelectedBoundingBoxFromPool(world, x, y, z);
 	}
-	
+
 	@Override
 	public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
-		
+
 		int meta = world.getBlockMetadata(x, y, z);
 		if(meta == 2){
 			return AxisAlignedBB.getBoundingBox(x, y, z, x, y, z);
@@ -195,7 +204,7 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
 		if (world.getBlockMetadata(x, y, z) == 0)
 			return new ItemStack(ModBlocks.draconiumBlock);
 		else if (world.getBlockMetadata(x, y, z) == 1)
-			return new ItemStack(Blocks.redstone_block);
+			return new ItemStack(BalanceConfigHandler.energyStorageStructureBlock, 1, BalanceConfigHandler.energyStorageStructureBlockMetadata);
 		else
 			return new ItemStack(Blocks.glass);
 	}

--- a/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerUpgradeModifier.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerUpgradeModifier.java
@@ -75,7 +75,7 @@ public class ContainerUpgradeModifier extends ContainerDataSync
 	{
 		return tile.isUseableByPlayer(player);
 	}
-	
+
 	@Override
 	public ItemStack transferStackInSlot(EntityPlayer player, int i)
 	{
@@ -132,7 +132,7 @@ public class ContainerUpgradeModifier extends ContainerDataSync
 
 		if (addCoreElseRemove)
 		{
-			if (!player.inventory.hasItem(CORES_INDEX[coreTier]) || totalCores >= coreSlots || upgrade.getUpgradePoints(stack) >= upgradableItem.getMaxUpgradePoints(upgrade.index)) return;
+			if (!player.inventory.hasItem(CORES_INDEX[coreTier]) || totalCores >= coreSlots || upgrade.getUpgradePoints(stack) >= upgradableItem.getMaxUpgradePoints(upgrade.index, stack)) return;
 			coresApplied[coreTier]++;
 			player.inventory.consumeInventoryItem(CORES_INDEX[coreTier]);
 			upgrade.setCoresApplied(stack, coresApplied);

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -40,6 +40,11 @@ public class BalanceConfigHandler
     public static int draconicWeaponsMaxTransfer = 500000;
     public static int draconicWeaponsEnergyPerAttack = 250;
     public static int draconicFireEnergyCostMultiptier = 30;
+    public static int grinderInternalEnergyBufferSize = 20000;
+    public static int grinderExternalEnergyBufferSize = 100000;
+    public static int grinderMaxReceive = 32000;
+    public static int grinderEnergyPerKill = 1000;
+    public static boolean grinderShouldUseLooting = false;
     private static Configuration config;
     public static void init(File modConfigurationDirectory)
     {
@@ -141,10 +146,25 @@ public class BalanceConfigHandler
         draconicFireEnergyCostMultiptier =
             getInteger("energy.weapons", "Arrow of Draconic Fire: Energy cost multiplier",
                        draconicFireEnergyCostMultiptier);
+        grinderInternalEnergyBufferSize = getInteger("energy.machines", "Mob Grinder: Internal energy buffer size (RF)",
+                                                     grinderInternalEnergyBufferSize);
+        grinderExternalEnergyBufferSize =
+            getInteger("energy.machines", "Mob Grinder: Main energy buffer size (RF)", grinderExternalEnergyBufferSize);
+        grinderMaxReceive =
+            getInteger("energy.machines", "Mob Grinder: Maximum energy reception rate (RF/t)", grinderMaxReceive);
+        grinderEnergyPerKill =
+            getInteger("energy.machines", "Mob Grinder: Amount of energy required to kill entity (RF)",
+                       grinderEnergyPerKill);
+        grinderShouldUseLooting =
+            getBoolean("tweaks.machines", "Mob Grinder: Use Looting enchantment", grinderShouldUseLooting);
         if (config.hasChanged())
         {
             config.save();
         }
+    }
+    private static boolean getBoolean(String category, String propertyName, boolean defaultValue)
+    {
+        return config.get(category, propertyName, defaultValue).getBoolean(defaultValue);
     }
     private static int getInteger(String categoty, String propertyName, int defaultValue)
     {

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -35,10 +35,12 @@ public class BalanceConfigHandler
     public static int wyvernWeaponsStoragePerUpgrade = 500000;
     public static int wyvernWeaponsMaxTransfer = 50000;
     public static int wyvernWeaponsEnergyPerAttack = 250;
+    public static int wyvernBowEnergyPerShot = 80;
     public static int draconicWeaponsBaseStorage = 10000000;
     public static int draconicWeaponsStoragePerUpgrade = 5000000;
     public static int draconicWeaponsMaxTransfer = 500000;
     public static int draconicWeaponsEnergyPerAttack = 250;
+    public static int draconicBowEnergyPerShot = 80;
     public static int draconicFireEnergyCostMultiptier = 30;
     public static int draconiumBlockEnergyToChange = 100000000;
     public static int draconiumBlockChargingSpeed = 10000000;
@@ -136,6 +138,8 @@ public class BalanceConfigHandler
         wyvernWeaponsEnergyPerAttack =
             getInteger("energy.weapons", "Wyvern Weapons: Amount of energy required to perform attack (RF)",
                        wyvernWeaponsEnergyPerAttack);
+        wyvernBowEnergyPerShot =
+            getInteger("energy.weapons", "Wyvern Bow: Amount of energy required to shoot (RF)", wyvernBowEnergyPerShot);
         draconicWeaponsBaseStorage =
             getInteger("energy.weapons", "Draconic Weapons: Base energy storage (RF)", draconicWeaponsBaseStorage);
         draconicWeaponsStoragePerUpgrade =
@@ -147,6 +151,8 @@ public class BalanceConfigHandler
         draconicWeaponsEnergyPerAttack =
             getInteger("energy.weapons", "Draconic Weapons: Amount of energy required to perform attack (RF)",
                        draconicWeaponsEnergyPerAttack);
+        draconicBowEnergyPerShot = getInteger("energy.weapons", "Draconic Bow: Amount of energy required to shoot (RF)",
+                                              draconicBowEnergyPerShot);
         draconicFireEnergyCostMultiptier =
             getInteger("energy.weapons", "Arrow of Draconic Fire: Energy cost multiplier",
                        draconicFireEnergyCostMultiptier);

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -26,10 +26,22 @@ public class BalanceConfigHandler
     public static final int wyvernWeaponsMaxAttackAOEUpgradePoints = 3;
     public static final int wyvernWeaponsMinAttackDamageUpgradePoints = 0;
     public static final int wyvernWeaponsMaxAttackDamageUpgradePoints = 8;
+    public static final int wyvernBowMinDrawSpeedUpgradePoints = 3;
+    public static final int wyvernBowMaxDrawSpeedUpgradePoints = 5;
+    public static final int wyvernBowMinArrowSpeedUpgradePoints = 1;
+    public static final int wyvernBowMaxArrowSpeedUpgradePoints = 10;
+    public static final int wyvernBowMinArrowDamageUpgradePoints = 2;
+    public static final int wyvernBowMaxArrowDamageUpgradePoints = 10;
     public static final int draconicWeaponsMinAttackAOEUpgradePoints = 2;
     public static final int draconicWeaponsMaxAttackAOEUpgradePoints = 5;
     public static final int draconicWeaponsMinAttackDamageUpgradePoints = 0;
     public static final int draconicWeaponsMaxAttackDamageUpgradePoints = 16;
+    public static final int draconicBowMinDrawSpeedUpgradePoints = 4;
+    public static final int draconicBowMaxDrawSpeedUpgradePoints = 6;
+    public static final int draconicBowMinArrowSpeedUpgradePoints = 3;
+    public static final int draconicBowMaxArrowSpeedUpgradePoints = 10;
+    public static final int draconicBowMinArrowDamageUpgradePoints = 3;
+    public static final int draconicBowMaxArrowDamageUpgradePoints = 20;
     public static int wyvernArmorBaseStorage = 1000000;
     public static int wyvernArmorStoragePerUpgrade = 500000;
     public static int wyvernArmorMaxTransfer = 50000;
@@ -93,6 +105,12 @@ public class BalanceConfigHandler
     public static int draconicWeaponsMaxCapacityUpgradePoints = 50;
     public static int draconicWeaponsMaxUpgrades = 6;
     public static int draconicWeaponsMaxUpgradePoints = 50;
+    public static int wyvernBowMaxCapacityUpgradePoints = 50;
+    public static int wyvernBowMaxUpgrades = 3;
+    public static int wyvernBowMaxUpgradePoints = 50;
+    public static int draconicBowMaxCapacityUpgradePoints = 50;
+    public static int draconicBowMaxUpgrades = 6;
+    public static int draconicBowMaxUpgradePoints = 50;
     public static int wyvernCapacitorMaxUpgrades = 3;
     public static int draconicCapacitorMaxUpgrades = 6;
     public static int fluxCapacitorMaxUpgradePoints = 50;
@@ -333,6 +351,56 @@ public class BalanceConfigHandler
                                                                      draconicWeaponsMinAttackDamageUpgradePoints) *
                                                                     EnumUpgrade.ARROW_DAMAGE.pointConversion,
                                                                     draconicWeaponsMaxCapacityUpgradePoints), 0);
+        wyvernBowMaxCapacityUpgradePoints = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernWeaponsBaseStorage) /
+                                                             (double) Math.max(wyvernWeaponsStoragePerUpgrade, 1)) *
+                                            EnumUpgrade.RF_CAPACITY.pointConversion;
+        wyvernBowMaxUpgrades =
+            getInteger("tweaks.weapons", "Wyvern Bow: Maximum amount of upgrades", wyvernBowMaxUpgrades, 0,
+                       (wyvernBowMaxDrawSpeedUpgradePoints - wyvernBowMinDrawSpeedUpgradePoints) *
+                       EnumUpgrade.DRAW_SPEED.pointConversion +
+                       (wyvernBowMaxArrowSpeedUpgradePoints - wyvernBowMinArrowSpeedUpgradePoints) *
+                       EnumUpgrade.ARROW_SPEED.pointConversion +
+                       (wyvernBowMaxArrowDamageUpgradePoints - wyvernBowMinArrowDamageUpgradePoints) *
+                       EnumUpgrade.ARROW_DAMAGE.pointConversion + wyvernBowMaxCapacityUpgradePoints);
+        wyvernBowMaxUpgradePoints =
+            getInteger("tweaks.weapons", "Wyvern Bow: Maximum amount of upgrade points", wyvernBowMaxUpgradePoints,
+                       wyvernBowMaxUpgrades, Integer.MAX_VALUE);
+        wyvernBowMaxCapacityUpgradePoints = Math.max(Math.min(wyvernBowMaxUpgradePoints -
+                                                              (wyvernBowMaxDrawSpeedUpgradePoints -
+                                                               wyvernBowMinDrawSpeedUpgradePoints) *
+                                                              EnumUpgrade.DRAW_SPEED.pointConversion -
+                                                              (wyvernBowMaxArrowSpeedUpgradePoints -
+                                                               wyvernBowMinArrowSpeedUpgradePoints) *
+                                                              EnumUpgrade.ARROW_SPEED.pointConversion -
+                                                              (wyvernBowMaxArrowDamageUpgradePoints -
+                                                               wyvernBowMinArrowDamageUpgradePoints) *
+                                                              EnumUpgrade.ARROW_DAMAGE.pointConversion,
+                                                              wyvernBowMaxCapacityUpgradePoints), 0);
+        draconicBowMaxCapacityUpgradePoints = (int) Math.floor(
+            (double) (Integer.MAX_VALUE - draconicWeaponsBaseStorage) /
+            (double) Math.max(draconicWeaponsStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
+        draconicBowMaxUpgrades =
+            getInteger("tweaks.weapons", "Draconic Bow: Maximum amount of upgrades", draconicBowMaxUpgrades, 0,
+                       (draconicBowMaxDrawSpeedUpgradePoints - draconicBowMinDrawSpeedUpgradePoints) *
+                       EnumUpgrade.DIG_SPEED.pointConversion +
+                       (draconicBowMaxArrowSpeedUpgradePoints - draconicBowMinArrowSpeedUpgradePoints) *
+                       EnumUpgrade.ARROW_SPEED.pointConversion +
+                       (draconicBowMaxArrowDamageUpgradePoints - draconicBowMinArrowDamageUpgradePoints) *
+                       EnumUpgrade.ARROW_DAMAGE.pointConversion + draconicBowMaxCapacityUpgradePoints);
+        draconicBowMaxUpgradePoints =
+            getInteger("tweaks.weapons", "Draconic Bow: Maximum amount of upgrade points", draconicBowMaxUpgradePoints,
+                       draconicBowMaxUpgrades, Integer.MAX_VALUE);
+        draconicBowMaxCapacityUpgradePoints = Math.max(Math.min(draconicBowMaxUpgradePoints -
+                                                                (draconicBowMaxDrawSpeedUpgradePoints -
+                                                                 draconicBowMinDrawSpeedUpgradePoints) *
+                                                                EnumUpgrade.DIG_SPEED.pointConversion -
+                                                                (draconicBowMaxArrowSpeedUpgradePoints -
+                                                                 draconicBowMinArrowSpeedUpgradePoints) *
+                                                                EnumUpgrade.ARROW_SPEED.pointConversion -
+                                                                (draconicBowMaxArrowDamageUpgradePoints -
+                                                                 draconicBowMinArrowDamageUpgradePoints) *
+                                                                EnumUpgrade.ARROW_DAMAGE.pointConversion,
+                                                                draconicBowMaxCapacityUpgradePoints), 0);
         int wyvernCapacitorUpgradesLimit = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernCapacitorBaseStorage) /
                                                             (double) Math.max(wyvernCapacitorStoragePerUpgrade, 1) /
                                                             2D);

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -2,6 +2,7 @@ package com.brandon3055.draconicevolution.common.handler;
 
 import java.io.File;
 
+import com.brandon3055.draconicevolution.common.utills.IUpgradableItem.EnumUpgrade;
 import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
@@ -21,6 +22,14 @@ public class BalanceConfigHandler
     public static final int draconicToolsMaxDigSpeedUpgradePoints = 32;
     public static final int draconicToolsMinDigDepthUpgradePoints = 1;
     public static final int draconicToolsMaxDigDepthUpgradePoints = 5;
+    public static final int wyvernWeaponsMinAttackAOEUpgradePoints = 1;
+    public static final int wyvernWeaponsMaxAttackAOEUpgradePoints = 3;
+    public static final int wyvernWeaponsMinAttackDamageUpgradePoints = 0;
+    public static final int wyvernWeaponsMaxAttackDamageUpgradePoints = 8;
+    public static final int draconicWeaponsMinAttackAOEUpgradePoints = 2;
+    public static final int draconicWeaponsMaxAttackAOEUpgradePoints = 5;
+    public static final int draconicWeaponsMinAttackDamageUpgradePoints = 0;
+    public static final int draconicWeaponsMaxAttackDamageUpgradePoints = 16;
     public static int wyvernArmorBaseStorage = 1000000;
     public static int wyvernArmorStoragePerUpgrade = 500000;
     public static int wyvernArmorMaxTransfer = 50000;
@@ -78,6 +87,12 @@ public class BalanceConfigHandler
     public static int draconicToolsMaxCapacityUpgradePoints = 50;
     public static int draconicToolsMaxUpgrades = 6;
     public static int draconicToolsMaxUpgradePoints = 50;
+    public static int wyvernWeaponsMaxCapacityUpgradePoints = 50;
+    public static int wyvernWeaponsMaxUpgrades = 3;
+    public static int wyvernWeaponsMaxUpgradePoints = 50;
+    public static int draconicWeaponsMaxCapacityUpgradePoints = 50;
+    public static int draconicWeaponsMaxUpgrades = 6;
+    public static int draconicWeaponsMaxUpgradePoints = 50;
     public static int wyvernCapacitorMaxUpgrades = 3;
     public static int draconicCapacitorMaxUpgrades = 6;
     public static int fluxCapacitorMaxUpgradePoints = 50;
@@ -93,6 +108,8 @@ public class BalanceConfigHandler
             config.load();
             config.setCategoryRequiresMcRestart("tweaks", true);
             config.setCategoryComment("tweaks.tools",
+                                      "Values in this category may be replaced automatically to prevent problems");
+            config.setCategoryComment("tweaks.weapons",
                                       "Values in this category may be replaced automatically to prevent problems");
             syncConfig();
         }
@@ -231,42 +248,91 @@ public class BalanceConfigHandler
         grinderEnergyPerKill =
             getInteger("energy.machines", "Mob Grinder: Amount of energy required to kill entity (RF)",
                        grinderEnergyPerKill);
-        wyvernToolsMaxCapacityUpgradePoints = (int) Math.floor(
-            (double) (Integer.MAX_VALUE - wyvernToolsBaseStorage) / (double) Math.max(wyvernToolsStoragePerUpgrade, 1));
+        wyvernToolsMaxCapacityUpgradePoints = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernToolsBaseStorage) /
+                                                               (double) Math.max(wyvernToolsStoragePerUpgrade, 1)) *
+                                              EnumUpgrade.RF_CAPACITY.pointConversion;
         wyvernToolsMaxUpgrades =
             getInteger("tweaks.tools", "Wyvern Tools: Maximum amount of upgrades", wyvernToolsMaxUpgrades, 0,
-                       (int) Math.ceil(
-                           (double) ((wyvernToolsMaxDigAOEUpgradePoints - wyvernToolsMinDigAOEUpgradePoints) +
-                                     (wyvernToolsMaxDigSpeedUpgradePoints - wyvernToolsMinDigSpeedUpgradePoints) +
-                                     wyvernToolsMaxCapacityUpgradePoints) / 2D));
+                       (wyvernToolsMaxDigAOEUpgradePoints - wyvernToolsMinDigAOEUpgradePoints) *
+                       EnumUpgrade.DIG_AOE.pointConversion +
+                       (wyvernToolsMaxDigSpeedUpgradePoints - wyvernToolsMinDigSpeedUpgradePoints) *
+                       EnumUpgrade.DIG_SPEED.pointConversion + wyvernToolsMaxCapacityUpgradePoints);
         wyvernToolsMaxUpgradePoints =
             getInteger("tweaks.tools", "Wyvern Tools: Maximum amount of upgrade points", wyvernToolsMaxUpgradePoints,
-                       wyvernToolsMaxUpgrades * 2, Integer.MAX_VALUE);
-        wyvernToolsMaxCapacityUpgradePoints = Math.max(Math.min(
-            wyvernToolsMaxUpgradePoints - (wyvernToolsMaxDigAOEUpgradePoints - wyvernToolsMinDigAOEUpgradePoints) -
-            (wyvernToolsMaxDigSpeedUpgradePoints - wyvernToolsMinDigSpeedUpgradePoints),
-            wyvernToolsMaxCapacityUpgradePoints), 0);
+                       wyvernToolsMaxUpgrades, Integer.MAX_VALUE);
+        wyvernToolsMaxCapacityUpgradePoints = Math.max(Math.min(wyvernToolsMaxUpgradePoints -
+                                                                (wyvernToolsMaxDigAOEUpgradePoints -
+                                                                 wyvernToolsMinDigAOEUpgradePoints) *
+                                                                EnumUpgrade.DIG_AOE.pointConversion -
+                                                                (wyvernToolsMaxDigSpeedUpgradePoints -
+                                                                 wyvernToolsMinDigSpeedUpgradePoints) *
+                                                                EnumUpgrade.DIG_SPEED.pointConversion,
+                                                                wyvernToolsMaxCapacityUpgradePoints), 0);
         draconicToolsMaxCapacityUpgradePoints = (int) Math.floor(
             (double) (Integer.MAX_VALUE - draconicToolsBaseStorage) /
-            (double) Math.max(draconicToolsStoragePerUpgrade, 1));
+            (double) Math.max(draconicToolsStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
         draconicToolsMaxUpgrades =
             getInteger("tweaks.tools", "Draconic Tools: Maximum amount of upgrades", draconicToolsMaxUpgrades, 0,
-                       (int) Math.ceil(
-                           (double) ((draconicToolsMaxDigAOEUpgradePoints - draconicToolsMinDigAOEUpgradePoints) +
-                                     (draconicToolsMaxDigSpeedUpgradePoints - draconicToolsMinDigSpeedUpgradePoints) +
-                                     (draconicToolsMaxDigDepthUpgradePoints - draconicToolsMinDigDepthUpgradePoints) +
-                                     draconicToolsMaxCapacityUpgradePoints) / 4D));
+                       (draconicToolsMaxDigAOEUpgradePoints - draconicToolsMinDigAOEUpgradePoints) *
+                       EnumUpgrade.DIG_AOE.pointConversion +
+                       (draconicToolsMaxDigSpeedUpgradePoints - draconicToolsMinDigSpeedUpgradePoints) *
+                       EnumUpgrade.DIG_SPEED.pointConversion +
+                       (draconicToolsMaxDigDepthUpgradePoints - draconicToolsMinDigDepthUpgradePoints) *
+                       EnumUpgrade.DIG_DEPTH.pointConversion + draconicToolsMaxCapacityUpgradePoints);
         draconicToolsMaxUpgradePoints = getInteger("tweaks.tools", "Draconic Tools: Maximum amount of upgrade points",
-                                                   draconicToolsMaxUpgradePoints, draconicToolsMaxUpgrades * 4,
+                                                   draconicToolsMaxUpgradePoints, draconicToolsMaxUpgrades,
                                                    Integer.MAX_VALUE);
         draconicToolsMaxCapacityUpgradePoints = Math.max(Math.min(draconicToolsMaxUpgradePoints -
                                                                   (draconicToolsMaxDigAOEUpgradePoints -
-                                                                   draconicToolsMinDigAOEUpgradePoints) -
+                                                                   draconicToolsMinDigAOEUpgradePoints) *
+                                                                  EnumUpgrade.DIG_AOE.pointConversion -
                                                                   (draconicToolsMaxDigSpeedUpgradePoints -
-                                                                   draconicToolsMinDigSpeedUpgradePoints) -
+                                                                   draconicToolsMinDigSpeedUpgradePoints) *
+                                                                  EnumUpgrade.DIG_SPEED.pointConversion -
                                                                   (draconicToolsMaxDigDepthUpgradePoints -
-                                                                   draconicToolsMinDigDepthUpgradePoints),
+                                                                   draconicToolsMinDigDepthUpgradePoints) *
+                                                                  EnumUpgrade.DIG_DEPTH.pointConversion,
                                                                   draconicToolsMaxCapacityUpgradePoints), 0);
+        wyvernWeaponsMaxCapacityUpgradePoints = (int) Math.floor(
+            (double) (Integer.MAX_VALUE - wyvernWeaponsBaseStorage) /
+            (double) Math.max(wyvernWeaponsStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
+        wyvernWeaponsMaxUpgrades =
+            getInteger("tweaks.weapons", "Wyvern Weapons: Maximum amount of upgrades", wyvernWeaponsMaxUpgrades, 0,
+                       (wyvernWeaponsMaxAttackAOEUpgradePoints - wyvernWeaponsMinAttackAOEUpgradePoints) *
+                       EnumUpgrade.ATTACK_AOE.pointConversion +
+                       (wyvernWeaponsMaxAttackDamageUpgradePoints - wyvernWeaponsMinAttackDamageUpgradePoints) *
+                       EnumUpgrade.ATTACK_DAMAGE.pointConversion + wyvernWeaponsMaxCapacityUpgradePoints);
+        wyvernWeaponsMaxUpgradePoints = getInteger("tweaks.weapons", "Wyvern Weapons: Maximum amount of upgrade points",
+                                                   wyvernWeaponsMaxUpgradePoints, wyvernWeaponsMaxUpgrades,
+                                                   Integer.MAX_VALUE);
+        wyvernWeaponsMaxCapacityUpgradePoints = Math.max(Math.min(wyvernWeaponsMaxUpgradePoints -
+                                                                  (wyvernWeaponsMaxAttackAOEUpgradePoints -
+                                                                   wyvernWeaponsMinAttackAOEUpgradePoints) *
+                                                                  EnumUpgrade.ATTACK_AOE.pointConversion -
+                                                                  (wyvernWeaponsMaxAttackDamageUpgradePoints -
+                                                                   wyvernWeaponsMinAttackDamageUpgradePoints) *
+                                                                  EnumUpgrade.ARROW_DAMAGE.pointConversion,
+                                                                  wyvernWeaponsMaxCapacityUpgradePoints), 0);
+        draconicWeaponsMaxCapacityUpgradePoints = (int) Math.floor(
+            (double) (Integer.MAX_VALUE - draconicWeaponsBaseStorage) /
+            (double) Math.max(draconicWeaponsStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
+        draconicWeaponsMaxUpgrades =
+            getInteger("tweaks.weapons", "Draconic Weapons: Maximum amount of upgrades", draconicWeaponsMaxUpgrades, 0,
+                       (draconicWeaponsMaxAttackAOEUpgradePoints - draconicWeaponsMinAttackAOEUpgradePoints) *
+                       EnumUpgrade.ATTACK_AOE.pointConversion +
+                       (draconicWeaponsMaxAttackDamageUpgradePoints - draconicWeaponsMinAttackDamageUpgradePoints) *
+                       EnumUpgrade.ARROW_DAMAGE.pointConversion + draconicWeaponsMaxCapacityUpgradePoints);
+        draconicWeaponsMaxUpgradePoints =
+            getInteger("tweaks.weapons", "Draconic Weapons: Maximum amount of upgrade points",
+                       draconicWeaponsMaxUpgradePoints, draconicWeaponsMaxUpgrades, Integer.MAX_VALUE);
+        draconicWeaponsMaxCapacityUpgradePoints = Math.max(Math.min(draconicWeaponsMaxUpgradePoints -
+                                                                    (draconicWeaponsMaxAttackAOEUpgradePoints -
+                                                                     draconicWeaponsMinAttackAOEUpgradePoints) *
+                                                                    EnumUpgrade.ATTACK_AOE.pointConversion -
+                                                                    (draconicWeaponsMaxAttackDamageUpgradePoints -
+                                                                     draconicWeaponsMinAttackDamageUpgradePoints) *
+                                                                    EnumUpgrade.ARROW_DAMAGE.pointConversion,
+                                                                    draconicWeaponsMaxCapacityUpgradePoints), 0);
         int wyvernCapacitorUpgradesLimit = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernCapacitorBaseStorage) /
                                                             (double) Math.max(wyvernCapacitorStoragePerUpgrade, 1) /
                                                             2D);

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -1,0 +1,56 @@
+package com.brandon3055.draconicevolution.common.handler;
+
+import java.io.File;
+
+import net.minecraftforge.common.config.Configuration;
+
+public class BalanceConfigHandler
+{
+    private static Configuration config;
+    public static int wyvernCapacitorBaseStorage = 80000000;
+    public static int wyvernCapacitorStoragePerUpgrade = 50000000;
+    public static int wyvernCapacitorMaxReceive = 1000000;
+    public static int wyvernCapacitorMaxExtract = 10000000;
+    public static int draconicCapacitorBaseStorage = 250000000;
+    public static int draconicCapacitorStoragePerUpgrade = 50000000;
+    public static int draconicCapacitorMaxReceive = 10000000;
+    public static int draconicCapacitorMaxExtract = 100000000;
+    public static void init(File modConfigurationDirectory)
+    {
+        if (config == null)
+        {
+            config = new Configuration(new File(modConfigurationDirectory, "DraconicEvolution.Balance.cfg"));
+            config.load();
+            syncConfig();
+        }
+    }
+    private static void syncConfig()
+    {
+        wyvernCapacitorBaseStorage = getInteger("energy.tools", "Wyvern Flux Capacitor: Base energy storage",
+                                                wyvernCapacitorBaseStorage);
+        wyvernCapacitorStoragePerUpgrade = getInteger("energy.tools", "Wyvern Flux Capacitor: " +
+                                                                      "Additional capacity per upgrade installed",
+                                                      wyvernCapacitorStoragePerUpgrade);
+        wyvernCapacitorMaxReceive = getInteger("energy.tools", "Wyvern Flux Capacitor: Maximum energy reception rate",
+                                               wyvernCapacitorMaxReceive);
+        wyvernCapacitorMaxExtract = getInteger("energy.tools", "Wyvern Flux Capacitor: Maximum energy extraction rate",
+                                               wyvernCapacitorMaxExtract);
+        draconicCapacitorBaseStorage = getInteger("energy.tools", "Draconic Flux Capacitor: Base energy storage",
+                                                  draconicCapacitorBaseStorage);
+        draconicCapacitorStoragePerUpgrade = getInteger("energy.tools", "Draconic Flux Capacitor: " +
+                                                                        "Additional capacity per upgrade installed",
+                                                        draconicCapacitorStoragePerUpgrade);
+        draconicCapacitorMaxReceive = getInteger("energy.tools", "Draconic Flux Capacitor: Maximum energy reception rate",
+                                                 draconicCapacitorMaxReceive);
+        draconicCapacitorMaxExtract = getInteger("energy.tools", "Draconic Flux Capacitor: Maximum energy extraction rate",
+                                                 draconicCapacitorMaxExtract);
+        if (config.hasChanged())
+        {
+            config.save();
+        }
+    }
+    private static int getInteger(String categoty, String propertyName, int defaultValue)
+    {
+        return config.get(categoty, propertyName, defaultValue).getInt(defaultValue);
+    }
+}

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -15,6 +15,12 @@ public class BalanceConfigHandler
     public static final int wyvernToolsMaxDigAOEUpgradePoints = 2;
     public static final int wyvernToolsMinDigSpeedUpgradePoints = 4;
     public static final int wyvernToolsMaxDigSpeedUpgradePoints = 16;
+    public static final int draconicToolsMinDigAOEUpgradePoints = 2;
+    public static final int draconicToolsMaxDigAOEUpgradePoints = 4;
+    public static final int draconicToolsMinDigSpeedUpgradePoints = 5;
+    public static final int draconicToolsMaxDigSpeedUpgradePoints = 32;
+    public static final int draconicToolsMinDigDepthUpgradePoints = 1;
+    public static final int draconicToolsMaxDigDepthUpgradePoints = 5;
     public static int wyvernArmorBaseStorage = 1000000;
     public static int wyvernArmorStoragePerUpgrade = 500000;
     public static int wyvernArmorMaxTransfer = 50000;
@@ -69,6 +75,9 @@ public class BalanceConfigHandler
     public static int wyvernToolsMaxCapacityUpgradePoints = 50;
     public static int wyvernToolsMaxUpgrades = 3;
     public static int wyvernToolsMaxUpgradePoints = 50;
+    public static int draconicToolsMaxCapacityUpgradePoints = 50;
+    public static int draconicToolsMaxUpgrades = 6;
+    public static int draconicToolsMaxUpgradePoints = 50;
     public static int wyvernCapacitorMaxUpgrades = 3;
     public static int draconicCapacitorMaxUpgrades = 6;
     public static int fluxCapacitorMaxUpgradePoints = 50;
@@ -237,6 +246,27 @@ public class BalanceConfigHandler
             wyvernToolsMaxUpgradePoints - (wyvernToolsMaxDigAOEUpgradePoints - wyvernToolsMinDigAOEUpgradePoints) -
             (wyvernToolsMaxDigSpeedUpgradePoints - wyvernToolsMinDigSpeedUpgradePoints),
             wyvernToolsMaxCapacityUpgradePoints), 0);
+        draconicToolsMaxCapacityUpgradePoints = (int) Math.floor(
+            (double) (Integer.MAX_VALUE - draconicToolsBaseStorage) /
+            (double) Math.max(draconicToolsStoragePerUpgrade, 1));
+        draconicToolsMaxUpgrades =
+            getInteger("tweaks.tools", "Draconic Tools: Maximum amount of upgrades", draconicToolsMaxUpgrades, 0,
+                       (int) Math.ceil(
+                           (double) ((draconicToolsMaxDigAOEUpgradePoints - draconicToolsMinDigAOEUpgradePoints) +
+                                     (draconicToolsMaxDigSpeedUpgradePoints - draconicToolsMinDigSpeedUpgradePoints) +
+                                     (draconicToolsMaxDigDepthUpgradePoints - draconicToolsMinDigDepthUpgradePoints) +
+                                     draconicToolsMaxCapacityUpgradePoints) / 4D));
+        draconicToolsMaxUpgradePoints = getInteger("tweaks.tools", "Draconic Tools: Maximum amount of upgrade points",
+                                                   draconicToolsMaxUpgradePoints, draconicToolsMaxUpgrades * 4,
+                                                   Integer.MAX_VALUE);
+        draconicToolsMaxCapacityUpgradePoints = Math.max(Math.min(draconicToolsMaxUpgradePoints -
+                                                                  (draconicToolsMaxDigAOEUpgradePoints -
+                                                                   draconicToolsMinDigAOEUpgradePoints) -
+                                                                  (draconicToolsMaxDigSpeedUpgradePoints -
+                                                                   draconicToolsMinDigSpeedUpgradePoints) -
+                                                                  (draconicToolsMaxDigDepthUpgradePoints -
+                                                                   draconicToolsMinDigDepthUpgradePoints),
+                                                                  draconicToolsMaxCapacityUpgradePoints), 0);
         int wyvernCapacitorUpgradesLimit = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernCapacitorBaseStorage) /
                                                             (double) Math.max(wyvernCapacitorStoragePerUpgrade, 1) /
                                                             2D);

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -40,6 +40,8 @@ public class BalanceConfigHandler
     public static int draconicWeaponsMaxTransfer = 500000;
     public static int draconicWeaponsEnergyPerAttack = 250;
     public static int draconicFireEnergyCostMultiptier = 30;
+    public static int draconiumBlockEnergyToChange = 100000000;
+    public static int draconiumBlockChargingSpeed = 10000000;
     public static int grinderInternalEnergyBufferSize = 20000;
     public static int grinderExternalEnergyBufferSize = 100000;
     public static int grinderMaxReceive = 32000;
@@ -146,6 +148,11 @@ public class BalanceConfigHandler
         draconicFireEnergyCostMultiptier =
             getInteger("energy.weapons", "Arrow of Draconic Fire: Energy cost multiplier",
                        draconicFireEnergyCostMultiptier);
+        draconiumBlockEnergyToChange =
+            getInteger("energy.misc", "Draconium Block: Amount of energy required to charge (RF)",
+                       draconiumBlockEnergyToChange);
+        draconiumBlockChargingSpeed =
+            getInteger("energy.misc", "Draconium Block: Maximum charging speed (RF/t)", draconiumBlockChargingSpeed);
         grinderInternalEnergyBufferSize = getInteger("energy.machines", "Mob Grinder: Internal energy buffer size (RF)",
                                                      grinderInternalEnergyBufferSize);
         grinderExternalEnergyBufferSize =

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -12,6 +12,8 @@ import net.minecraftforge.common.config.Property;
 
 public class BalanceConfigHandler
 {
+    public static final int wyvernArmorMinShieldRecovery = 5;
+    public static final int draconicArmorMinShieldRecovery = 5;
     public static final int wyvernToolsMinDigAOEUpgradePoints = 1;
     public static final int wyvernToolsMaxDigAOEUpgradePoints = 2;
     public static final int wyvernToolsMinDigSpeedUpgradePoints = 4;
@@ -101,6 +103,12 @@ public class BalanceConfigHandler
     public static int grinderExternalEnergyBufferSize = 100000;
     public static int grinderMaxReceive = 32000;
     public static int grinderEnergyPerKill = 1000;
+    public static int wyvernArmorMaxCapacityUpgradePoints = 50;
+    public static int wyvernArmorMaxUpgrades = 3;
+    public static int wyvernArmorMaxUpgradePoints = 50;
+    public static int draconicArmorMaxCapacityUpgradePoints = 50;
+    public static int draconicArmorMaxUpgrades = 6;
+    public static int draconicArmorMaxUpgradePoints = 50;
     public static int wyvernToolsMaxCapacityUpgradePoints = 50;
     public static int wyvernToolsMaxUpgrades = 3;
     public static int wyvernToolsMaxUpgradePoints = 50;
@@ -136,6 +144,8 @@ public class BalanceConfigHandler
             config = new Configuration(new File(modConfigurationDirectory, "DraconicEvolution.Balance.cfg"));
             config.load();
             config.setCategoryRequiresMcRestart("tweaks", true);
+            config.setCategoryComment("tweaks.armor",
+                                      "Values in this category may be replaced automatically to prevent problems");
             config.setCategoryComment("tweaks.tools",
                                       "Values in this category may be replaced automatically to prevent problems");
             config.setCategoryComment("tweaks.weapons",
@@ -277,6 +287,26 @@ public class BalanceConfigHandler
         grinderEnergyPerKill =
             getInteger("energy.machines", "Mob Grinder: Amount of energy required to kill entity (RF)",
                        grinderEnergyPerKill);
+        wyvernArmorMaxCapacityUpgradePoints = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernArmorBaseStorage) /
+                                                               (double) Math.max(wyvernArmorStoragePerUpgrade, 1)) *
+                                              EnumUpgrade.RF_CAPACITY.pointConversion;
+        wyvernArmorMaxUpgrades =
+            getInteger("tweaks.armor", "Wyvern Armor: Maximum amount of upgrades", wyvernArmorMaxUpgrades);
+        wyvernArmorMaxUpgradePoints =
+            getInteger("tweaks.armor", "Wyvern Armor: Maximum amount of upgrade points", wyvernArmorMaxUpgradePoints,
+                       wyvernArmorMaxUpgrades, Integer.MAX_VALUE);
+        wyvernArmorMaxCapacityUpgradePoints =
+            Math.max(Math.min(wyvernArmorMaxUpgradePoints, wyvernArmorMaxCapacityUpgradePoints), 0);
+        draconicArmorMaxCapacityUpgradePoints = (int) Math.floor(
+            (double) (Integer.MAX_VALUE - draconicArmorBaseStorage) / Math.max(draconicArmorStoragePerUpgrade, 1)) *
+                                                EnumUpgrade.RF_CAPACITY.pointConversion;
+        draconicArmorMaxUpgrades =
+            getInteger("tweaks.armor", "Draconic Armor: Maximum amount of upgrades", draconicArmorMaxUpgrades);
+        draconicArmorMaxUpgradePoints = getInteger("tweaks.armor", "Draconic Armor: Maximum amount of upgrade points",
+                                                   draconicArmorMaxUpgradePoints, draconicArmorMaxUpgrades,
+                                                   Integer.MAX_VALUE);
+        draconicArmorMaxCapacityUpgradePoints =
+            Math.max(Math.min(draconicArmorMaxUpgradePoints, draconicArmorMaxCapacityUpgradePoints), 0);
         wyvernToolsMaxCapacityUpgradePoints = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernToolsBaseStorage) /
                                                                (double) Math.max(wyvernToolsStoragePerUpgrade, 1)) *
                                               EnumUpgrade.RF_CAPACITY.pointConversion;

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -42,6 +42,14 @@ public class BalanceConfigHandler
     public static final int draconicBowMaxArrowSpeedUpgradePoints = 10;
     public static final int draconicBowMinArrowDamageUpgradePoints = 3;
     public static final int draconicBowMaxArrowDamageUpgradePoints = 20;
+    public static final int draconicStaffMinDigAOEUpgradePoints = 3;
+    public static final int draconicStaffMaxDigAOEUpgradePoints = 5;
+    public static final int draconicStaffMinDigDepthUpgradePoints = 7;
+    public static final int draconicStaffMaxDigDepthUpgradePoints = 11;
+    public static final int draconicStaffMinAttackAOEUpgradePoints = 3;
+    public static final int draconicStaffMaxAttackAOEUpgradePoints = 13;
+    public static final int draconicStaffMinAttackDamageUpgradePoints = 0;
+    public static final int draconicStaffMaxAttackDamageUpgradePoints = 64;
     public static int wyvernArmorBaseStorage = 1000000;
     public static int wyvernArmorStoragePerUpgrade = 500000;
     public static int wyvernArmorMaxTransfer = 50000;
@@ -111,6 +119,9 @@ public class BalanceConfigHandler
     public static int draconicBowMaxCapacityUpgradePoints = 50;
     public static int draconicBowMaxUpgrades = 6;
     public static int draconicBowMaxUpgradePoints = 50;
+    public static int draconicStaffMaxCapacityUpgradePoints = 50;
+    public static int draconicStaffMaxUpgrades = 12;
+    public static int draconicStaffMaxUpgradePoints = 50;
     public static int wyvernCapacitorMaxUpgrades = 3;
     public static int draconicCapacitorMaxUpgrades = 6;
     public static int fluxCapacitorMaxUpgradePoints = 50;
@@ -401,6 +412,26 @@ public class BalanceConfigHandler
                                                                  draconicBowMinArrowDamageUpgradePoints) *
                                                                 EnumUpgrade.ARROW_DAMAGE.pointConversion,
                                                                 draconicBowMaxCapacityUpgradePoints), 0);
+        draconicStaffMaxCapacityUpgradePoints = (int) Math.floor(
+            (double) (Integer.MAX_VALUE - draconicToolsBaseStorage * 2 - draconicWeaponsBaseStorage) /
+            (double) Math.max(draconicToolsStoragePerUpgrade + draconicWeaponsStoragePerUpgrade, 1)) *
+                                                EnumUpgrade.RF_CAPACITY.pointConversion;
+        draconicStaffMaxUpgrades = draconicToolsMaxUpgrades + draconicWeaponsMaxUpgrades;
+        draconicStaffMaxUpgradePoints = draconicToolsMaxUpgradePoints + draconicWeaponsMaxUpgradePoints;
+        draconicStaffMaxCapacityUpgradePoints = Math.max(Math.min(draconicStaffMaxUpgradePoints -
+                                                                  (draconicStaffMaxDigAOEUpgradePoints -
+                                                                   draconicStaffMinDigAOEUpgradePoints) *
+                                                                  EnumUpgrade.DIG_AOE.pointConversion -
+                                                                  (draconicStaffMaxDigDepthUpgradePoints -
+                                                                   draconicStaffMinDigDepthUpgradePoints) *
+                                                                  EnumUpgrade.DIG_DEPTH.pointConversion -
+                                                                  (draconicStaffMaxAttackAOEUpgradePoints -
+                                                                   draconicStaffMinAttackAOEUpgradePoints) *
+                                                                  EnumUpgrade.ATTACK_AOE.pointConversion -
+                                                                  (draconicStaffMaxAttackDamageUpgradePoints -
+                                                                   draconicStaffMinAttackDamageUpgradePoints) *
+                                                                  EnumUpgrade.ATTACK_DAMAGE.pointConversion,
+                                                                  draconicStaffMaxCapacityUpgradePoints), 0);
         int wyvernCapacitorUpgradesLimit = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernCapacitorBaseStorage) /
                                                             (double) Math.max(wyvernCapacitorStoragePerUpgrade, 1) /
                                                             2D);

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -42,6 +42,8 @@ public class BalanceConfigHandler
     public static int draconicFireEnergyCostMultiptier = 30;
     public static int draconiumBlockEnergyToChange = 100000000;
     public static int draconiumBlockChargingSpeed = 10000000;
+    public static int energyInfuserStorage = 10000000;
+    public static int energyInfuserMaxTransfer = 10000000;
     public static int grinderInternalEnergyBufferSize = 20000;
     public static int grinderExternalEnergyBufferSize = 100000;
     public static int grinderMaxReceive = 32000;
@@ -153,6 +155,10 @@ public class BalanceConfigHandler
                        draconiumBlockEnergyToChange);
         draconiumBlockChargingSpeed =
             getInteger("energy.misc", "Draconium Block: Maximum charging speed (RF/t)", draconiumBlockChargingSpeed);
+        energyInfuserStorage =
+            getInteger("energy.machines", "Energy Infuser: Energy buffer size (RF)", energyInfuserStorage);
+        energyInfuserMaxTransfer = getInteger("energy.machines", "Energy Infuser: Maximum energy transfer rate (RF/t)",
+                                              energyInfuserMaxTransfer);
         grinderInternalEnergyBufferSize = getInteger("energy.machines", "Mob Grinder: Internal energy buffer size (RF)",
                                                      grinderInternalEnergyBufferSize);
         grinderExternalEnergyBufferSize =

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -6,7 +6,10 @@ import net.minecraftforge.common.config.Configuration;
 
 public class BalanceConfigHandler
 {
-    private static Configuration config;
+    public static int wyvernToolsBaseStorage = 1000000;
+    public static int wyvernToolsStoragePerUpgrade = 500000;
+    public static int wyvernToolsMaxTransfer = 50000;
+    public static int wyvernToolsEnergyPerAction = 80;
     public static int wyvernCapacitorBaseStorage = 80000000;
     public static int wyvernCapacitorStoragePerUpgrade = 50000000;
     public static int wyvernCapacitorMaxReceive = 1000000;
@@ -15,6 +18,7 @@ public class BalanceConfigHandler
     public static int draconicCapacitorStoragePerUpgrade = 50000000;
     public static int draconicCapacitorMaxReceive = 10000000;
     public static int draconicCapacitorMaxExtract = 100000000;
+    private static Configuration config;
     public static void init(File modConfigurationDirectory)
     {
         if (config == null)
@@ -26,24 +30,38 @@ public class BalanceConfigHandler
     }
     private static void syncConfig()
     {
-        wyvernCapacitorBaseStorage = getInteger("energy.tools", "Wyvern Flux Capacitor: Base energy storage",
-                                                wyvernCapacitorBaseStorage);
-        wyvernCapacitorStoragePerUpgrade = getInteger("energy.tools", "Wyvern Flux Capacitor: " +
-                                                                      "Additional capacity per upgrade installed",
-                                                      wyvernCapacitorStoragePerUpgrade);
-        wyvernCapacitorMaxReceive = getInteger("energy.tools", "Wyvern Flux Capacitor: Maximum energy reception rate",
-                                               wyvernCapacitorMaxReceive);
-        wyvernCapacitorMaxExtract = getInteger("energy.tools", "Wyvern Flux Capacitor: Maximum energy extraction rate",
-                                               wyvernCapacitorMaxExtract);
-        draconicCapacitorBaseStorage = getInteger("energy.tools", "Draconic Flux Capacitor: Base energy storage",
+        wyvernToolsBaseStorage =
+            getInteger("energy.tools", "Wyvern Tools: Base energy storage (RF)", wyvernToolsBaseStorage);
+        wyvernToolsStoragePerUpgrade =
+            getInteger("energy.tools", "Wyvern Tools: Additional energy storage per upgrade installed (RF)",
+                       wyvernToolsStoragePerUpgrade);
+        wyvernToolsMaxTransfer =
+            getInteger("energy.tools", "Wyvern Tools: Maximum energy transfer rate (RF/t)", wyvernToolsMaxTransfer);
+        wyvernToolsEnergyPerAction =
+            getInteger("energy.tools", "Wyvern Tools: Amount of energy required to perform action (RF)",
+                       wyvernToolsEnergyPerAction);
+        wyvernCapacitorBaseStorage =
+            getInteger("energy.tools", "Wyvern Flux Capacitor: Base energy storage (RF)", wyvernCapacitorBaseStorage);
+        wyvernCapacitorStoragePerUpgrade =
+            getInteger("energy.tools", "Wyvern Flux Capacitor: Additional energy storage per upgrade installed (RF)",
+                       wyvernCapacitorStoragePerUpgrade);
+        wyvernCapacitorMaxReceive =
+            getInteger("energy.tools", "Wyvern Flux Capacitor: Maximum energy reception rate (RF/t)",
+                       wyvernCapacitorMaxReceive);
+        wyvernCapacitorMaxExtract =
+            getInteger("energy.tools", "Wyvern Flux Capacitor: Maximum energy extraction rate (RF/t)",
+                       wyvernCapacitorMaxExtract);
+        draconicCapacitorBaseStorage = getInteger("energy.tools", "Draconic Flux Capacitor: Base energy storage (RF)",
                                                   draconicCapacitorBaseStorage);
-        draconicCapacitorStoragePerUpgrade = getInteger("energy.tools", "Draconic Flux Capacitor: " +
-                                                                        "Additional capacity per upgrade installed",
-                                                        draconicCapacitorStoragePerUpgrade);
-        draconicCapacitorMaxReceive = getInteger("energy.tools", "Draconic Flux Capacitor: Maximum energy reception rate",
-                                                 draconicCapacitorMaxReceive);
-        draconicCapacitorMaxExtract = getInteger("energy.tools", "Draconic Flux Capacitor: Maximum energy extraction rate",
-                                                 draconicCapacitorMaxExtract);
+        draconicCapacitorStoragePerUpgrade =
+            getInteger("energy.tools", "Draconic Flux Capacitor: Additional energy storage per upgrade installed (RF)",
+                       draconicCapacitorStoragePerUpgrade);
+        draconicCapacitorMaxReceive =
+            getInteger("energy.tools", "Draconic Flux Capacitor: Maximum energy reception rate (RF/t)",
+                       draconicCapacitorMaxReceive);
+        draconicCapacitorMaxExtract =
+            getInteger("energy.tools", "Draconic Flux Capacitor: Maximum energy extraction rate (RF/t)",
+                       draconicCapacitorMaxExtract);
         if (config.hasChanged())
         {
             config.save();

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -22,6 +22,15 @@ public class BalanceConfigHandler
     public static int draconicCapacitorStoragePerUpgrade = 50000000;
     public static int draconicCapacitorMaxReceive = 10000000;
     public static int draconicCapacitorMaxExtract = 100000000;
+    public static int wyvernWeaponsBaseStorage = 1000000;
+    public static int wyvernWeaponsStoragePerUpgrade = 500000;
+    public static int wyvernWeaponsMaxTransfer = 50000;
+    public static int wyvernWeaponsEnergyPerAttack = 250;
+    public static int draconicWeaponsBaseStorage = 10000000;
+    public static int draconicWeaponsStoragePerUpgrade = 5000000;
+    public static int draconicWeaponsMaxTransfer = 500000;
+    public static int draconicWeaponsEnergyPerAttack = 250;
+    public static int draconicFireEnergyCostMultiptier = 30;
     private static Configuration config;
     public static void init(File modConfigurationDirectory)
     {
@@ -76,6 +85,30 @@ public class BalanceConfigHandler
         draconicCapacitorMaxExtract =
             getInteger("energy.tools", "Draconic Flux Capacitor: Maximum energy extraction rate (RF/t)",
                        draconicCapacitorMaxExtract);
+        wyvernWeaponsBaseStorage =
+            getInteger("energy.weapons", "Wyvern Weapons: Base energy storage (RF)", wyvernWeaponsBaseStorage);
+        wyvernWeaponsStoragePerUpgrade =
+            getInteger("energy.weapons", "Wyvern Weapons: Additional energy storage per upgrade installed (RF)",
+                       wyvernWeaponsStoragePerUpgrade);
+        wyvernWeaponsMaxTransfer = getInteger("energy.weapons", "Wyvern Weapons: Maximum energy transfer rate (RF/t)",
+                                              wyvernWeaponsMaxTransfer);
+        wyvernWeaponsEnergyPerAttack =
+            getInteger("energy.weapons", "Wyvern Weapons: Amount of energy required to perform attack (RF)",
+                       wyvernWeaponsEnergyPerAttack);
+        draconicWeaponsBaseStorage =
+            getInteger("energy.weapons", "Draconic Weapons: Base energy storage (RF)", draconicWeaponsBaseStorage);
+        draconicWeaponsStoragePerUpgrade =
+            getInteger("energy.weapons", "Draconic Weapons: Additional energy storage per upgrade installed (RF)",
+                       draconicWeaponsStoragePerUpgrade);
+        draconicWeaponsMaxTransfer =
+            getInteger("energy.weapons", "Draconic Weapons: Maximum energy transfer rate (RF/t)",
+                       draconicWeaponsMaxTransfer);
+        draconicWeaponsEnergyPerAttack =
+            getInteger("energy.weapons", "Draconic Weapons: Amount of energy required to perform attack (RF)",
+                       draconicWeaponsEnergyPerAttack);
+        draconicFireEnergyCostMultiptier =
+            getInteger("energy.weapons", "Arrow of Draconic Fire: Energy cost multiplier",
+                       draconicFireEnergyCostMultiptier);
         if (config.hasChanged())
         {
             config.save();

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -130,9 +130,12 @@ public class BalanceConfigHandler
     public static int draconicStaffMaxCapacityUpgradePoints = 50;
     public static int draconicStaffMaxUpgrades = 12;
     public static int draconicStaffMaxUpgradePoints = 50;
+    public static int wyvernCapacitorMaxUpgradePoints = 50;
+    public static int wyvernCapacitorMaxCapacityUpgradePoints = 50;
     public static int wyvernCapacitorMaxUpgrades = 3;
+    public static int draconicCapacitorMaxUpgradePoints = 50;
+    public static int draconicCapacitorMaxCapacityUpgradePoints = 50;
     public static int draconicCapacitorMaxUpgrades = 6;
-    public static int fluxCapacitorMaxUpgradePoints = 50;
     public static Block energyStorageStructureBlock = null;
     public static int energyStorageStructureBlockMetadata = 0;
     public static boolean grinderShouldUseLooting = false;
@@ -319,14 +322,8 @@ public class BalanceConfigHandler
         wyvernToolsMaxUpgradePoints =
             getInteger("tweaks.tools", "Wyvern Tools: Maximum amount of upgrade points", wyvernToolsMaxUpgradePoints,
                        wyvernToolsMaxUpgrades, Integer.MAX_VALUE);
-        wyvernToolsMaxCapacityUpgradePoints = Math.max(Math.min(wyvernToolsMaxUpgradePoints -
-                                                                (wyvernToolsMaxDigAOEUpgradePoints -
-                                                                 wyvernToolsMinDigAOEUpgradePoints) *
-                                                                EnumUpgrade.DIG_AOE.pointConversion -
-                                                                (wyvernToolsMaxDigSpeedUpgradePoints -
-                                                                 wyvernToolsMinDigSpeedUpgradePoints) *
-                                                                EnumUpgrade.DIG_SPEED.pointConversion,
-                                                                wyvernToolsMaxCapacityUpgradePoints), 0);
+        wyvernToolsMaxCapacityUpgradePoints =
+            Math.max(Math.min(wyvernToolsMaxUpgradePoints, wyvernToolsMaxCapacityUpgradePoints), 0);
         draconicToolsMaxCapacityUpgradePoints = (int) Math.floor(
             (double) (Integer.MAX_VALUE - draconicToolsBaseStorage) /
             (double) Math.max(draconicToolsStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
@@ -341,17 +338,8 @@ public class BalanceConfigHandler
         draconicToolsMaxUpgradePoints = getInteger("tweaks.tools", "Draconic Tools: Maximum amount of upgrade points",
                                                    draconicToolsMaxUpgradePoints, draconicToolsMaxUpgrades,
                                                    Integer.MAX_VALUE);
-        draconicToolsMaxCapacityUpgradePoints = Math.max(Math.min(draconicToolsMaxUpgradePoints -
-                                                                  (draconicToolsMaxDigAOEUpgradePoints -
-                                                                   draconicToolsMinDigAOEUpgradePoints) *
-                                                                  EnumUpgrade.DIG_AOE.pointConversion -
-                                                                  (draconicToolsMaxDigSpeedUpgradePoints -
-                                                                   draconicToolsMinDigSpeedUpgradePoints) *
-                                                                  EnumUpgrade.DIG_SPEED.pointConversion -
-                                                                  (draconicToolsMaxDigDepthUpgradePoints -
-                                                                   draconicToolsMinDigDepthUpgradePoints) *
-                                                                  EnumUpgrade.DIG_DEPTH.pointConversion,
-                                                                  draconicToolsMaxCapacityUpgradePoints), 0);
+        draconicToolsMaxCapacityUpgradePoints =
+            Math.max(Math.min(draconicToolsMaxUpgradePoints, draconicToolsMaxCapacityUpgradePoints), 0);
         wyvernWeaponsMaxCapacityUpgradePoints = (int) Math.floor(
             (double) (Integer.MAX_VALUE - wyvernWeaponsBaseStorage) /
             (double) Math.max(wyvernWeaponsStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
@@ -364,14 +352,8 @@ public class BalanceConfigHandler
         wyvernWeaponsMaxUpgradePoints = getInteger("tweaks.weapons", "Wyvern Weapons: Maximum amount of upgrade points",
                                                    wyvernWeaponsMaxUpgradePoints, wyvernWeaponsMaxUpgrades,
                                                    Integer.MAX_VALUE);
-        wyvernWeaponsMaxCapacityUpgradePoints = Math.max(Math.min(wyvernWeaponsMaxUpgradePoints -
-                                                                  (wyvernWeaponsMaxAttackAOEUpgradePoints -
-                                                                   wyvernWeaponsMinAttackAOEUpgradePoints) *
-                                                                  EnumUpgrade.ATTACK_AOE.pointConversion -
-                                                                  (wyvernWeaponsMaxAttackDamageUpgradePoints -
-                                                                   wyvernWeaponsMinAttackDamageUpgradePoints) *
-                                                                  EnumUpgrade.ARROW_DAMAGE.pointConversion,
-                                                                  wyvernWeaponsMaxCapacityUpgradePoints), 0);
+        wyvernWeaponsMaxCapacityUpgradePoints =
+            Math.max(Math.min(wyvernWeaponsMaxUpgradePoints, wyvernWeaponsMaxCapacityUpgradePoints), 0);
         draconicWeaponsMaxCapacityUpgradePoints = (int) Math.floor(
             (double) (Integer.MAX_VALUE - draconicWeaponsBaseStorage) /
             (double) Math.max(draconicWeaponsStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
@@ -384,14 +366,8 @@ public class BalanceConfigHandler
         draconicWeaponsMaxUpgradePoints =
             getInteger("tweaks.weapons", "Draconic Weapons: Maximum amount of upgrade points",
                        draconicWeaponsMaxUpgradePoints, draconicWeaponsMaxUpgrades, Integer.MAX_VALUE);
-        draconicWeaponsMaxCapacityUpgradePoints = Math.max(Math.min(draconicWeaponsMaxUpgradePoints -
-                                                                    (draconicWeaponsMaxAttackAOEUpgradePoints -
-                                                                     draconicWeaponsMinAttackAOEUpgradePoints) *
-                                                                    EnumUpgrade.ATTACK_AOE.pointConversion -
-                                                                    (draconicWeaponsMaxAttackDamageUpgradePoints -
-                                                                     draconicWeaponsMinAttackDamageUpgradePoints) *
-                                                                    EnumUpgrade.ARROW_DAMAGE.pointConversion,
-                                                                    draconicWeaponsMaxCapacityUpgradePoints), 0);
+        draconicWeaponsMaxCapacityUpgradePoints =
+            Math.max(Math.min(draconicWeaponsMaxUpgradePoints, draconicWeaponsMaxCapacityUpgradePoints), 0);
         wyvernBowMaxCapacityUpgradePoints = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernWeaponsBaseStorage) /
                                                              (double) Math.max(wyvernWeaponsStoragePerUpgrade, 1)) *
                                             EnumUpgrade.RF_CAPACITY.pointConversion;
@@ -406,17 +382,8 @@ public class BalanceConfigHandler
         wyvernBowMaxUpgradePoints =
             getInteger("tweaks.weapons", "Wyvern Bow: Maximum amount of upgrade points", wyvernBowMaxUpgradePoints,
                        wyvernBowMaxUpgrades, Integer.MAX_VALUE);
-        wyvernBowMaxCapacityUpgradePoints = Math.max(Math.min(wyvernBowMaxUpgradePoints -
-                                                              (wyvernBowMaxDrawSpeedUpgradePoints -
-                                                               wyvernBowMinDrawSpeedUpgradePoints) *
-                                                              EnumUpgrade.DRAW_SPEED.pointConversion -
-                                                              (wyvernBowMaxArrowSpeedUpgradePoints -
-                                                               wyvernBowMinArrowSpeedUpgradePoints) *
-                                                              EnumUpgrade.ARROW_SPEED.pointConversion -
-                                                              (wyvernBowMaxArrowDamageUpgradePoints -
-                                                               wyvernBowMinArrowDamageUpgradePoints) *
-                                                              EnumUpgrade.ARROW_DAMAGE.pointConversion,
-                                                              wyvernBowMaxCapacityUpgradePoints), 0);
+        wyvernBowMaxCapacityUpgradePoints =
+            Math.max(Math.min(wyvernBowMaxUpgradePoints, wyvernBowMaxCapacityUpgradePoints), 0);
         draconicBowMaxCapacityUpgradePoints = (int) Math.floor(
             (double) (Integer.MAX_VALUE - draconicWeaponsBaseStorage) /
             (double) Math.max(draconicWeaponsStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
@@ -431,52 +398,38 @@ public class BalanceConfigHandler
         draconicBowMaxUpgradePoints =
             getInteger("tweaks.weapons", "Draconic Bow: Maximum amount of upgrade points", draconicBowMaxUpgradePoints,
                        draconicBowMaxUpgrades, Integer.MAX_VALUE);
-        draconicBowMaxCapacityUpgradePoints = Math.max(Math.min(draconicBowMaxUpgradePoints -
-                                                                (draconicBowMaxDrawSpeedUpgradePoints -
-                                                                 draconicBowMinDrawSpeedUpgradePoints) *
-                                                                EnumUpgrade.DIG_SPEED.pointConversion -
-                                                                (draconicBowMaxArrowSpeedUpgradePoints -
-                                                                 draconicBowMinArrowSpeedUpgradePoints) *
-                                                                EnumUpgrade.ARROW_SPEED.pointConversion -
-                                                                (draconicBowMaxArrowDamageUpgradePoints -
-                                                                 draconicBowMinArrowDamageUpgradePoints) *
-                                                                EnumUpgrade.ARROW_DAMAGE.pointConversion,
-                                                                draconicBowMaxCapacityUpgradePoints), 0);
+        draconicBowMaxCapacityUpgradePoints =
+            Math.max(Math.min(draconicBowMaxUpgradePoints, draconicBowMaxCapacityUpgradePoints), 0);
         draconicStaffMaxCapacityUpgradePoints = (int) Math.floor(
             (double) (Integer.MAX_VALUE - draconicToolsBaseStorage * 2 - draconicWeaponsBaseStorage) /
             (double) Math.max(draconicToolsStoragePerUpgrade + draconicWeaponsStoragePerUpgrade, 1)) *
                                                 EnumUpgrade.RF_CAPACITY.pointConversion;
         draconicStaffMaxUpgrades = draconicToolsMaxUpgrades + draconicWeaponsMaxUpgrades;
         draconicStaffMaxUpgradePoints = draconicToolsMaxUpgradePoints + draconicWeaponsMaxUpgradePoints;
-        draconicStaffMaxCapacityUpgradePoints = Math.max(Math.min(draconicStaffMaxUpgradePoints -
-                                                                  (draconicStaffMaxDigAOEUpgradePoints -
-                                                                   draconicStaffMinDigAOEUpgradePoints) *
-                                                                  EnumUpgrade.DIG_AOE.pointConversion -
-                                                                  (draconicStaffMaxDigDepthUpgradePoints -
-                                                                   draconicStaffMinDigDepthUpgradePoints) *
-                                                                  EnumUpgrade.DIG_DEPTH.pointConversion -
-                                                                  (draconicStaffMaxAttackAOEUpgradePoints -
-                                                                   draconicStaffMinAttackAOEUpgradePoints) *
-                                                                  EnumUpgrade.ATTACK_AOE.pointConversion -
-                                                                  (draconicStaffMaxAttackDamageUpgradePoints -
-                                                                   draconicStaffMinAttackDamageUpgradePoints) *
-                                                                  EnumUpgrade.ATTACK_DAMAGE.pointConversion,
-                                                                  draconicStaffMaxCapacityUpgradePoints), 0);
-        int wyvernCapacitorUpgradesLimit = (int) Math.floor((double) (Integer.MAX_VALUE - wyvernCapacitorBaseStorage) /
-                                                            (double) Math.max(wyvernCapacitorStoragePerUpgrade, 1) /
-                                                            2D);
-        int draconicCapacitorUpgradesLimit =
-            (int) Math.floor((double) (Integer.MAX_VALUE - draconicCapacitorBaseStorage) /
-                             (double) Math.max(draconicCapacitorStoragePerUpgrade, 1) / 4D);
+        draconicStaffMaxCapacityUpgradePoints =
+            Math.max(Math.min(draconicStaffMaxUpgradePoints, draconicStaffMaxCapacityUpgradePoints), 0);
+        wyvernCapacitorMaxCapacityUpgradePoints = (int) Math.floor(
+            (double) (Integer.MAX_VALUE - wyvernCapacitorBaseStorage) /
+            (double) Math.max(wyvernCapacitorStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
         wyvernCapacitorMaxUpgrades =
             getInteger("tweaks.tools", "Wyvern Flux Capacitor: Maximum amount of upgrades", wyvernCapacitorMaxUpgrades,
-                       0, wyvernCapacitorUpgradesLimit);
+                       0, wyvernCapacitorMaxCapacityUpgradePoints);
+        wyvernCapacitorMaxUpgradePoints =
+            getInteger("tweaks.tools", "Wyvern Flux Capacitor: Maximum amount of upgrade points",
+                       wyvernCapacitorMaxUpgradePoints, wyvernCapacitorMaxUpgrades, Integer.MAX_VALUE);
+        wyvernCapacitorMaxCapacityUpgradePoints =
+            Math.max(Math.min(wyvernCapacitorMaxUpgradePoints, wyvernCapacitorMaxCapacityUpgradePoints), 0);
+        draconicCapacitorMaxCapacityUpgradePoints = (int) Math.floor(
+            (double) (Integer.MAX_VALUE - draconicCapacitorBaseStorage) /
+            (double) Math.max(draconicCapacitorStoragePerUpgrade, 1)) * EnumUpgrade.RF_CAPACITY.pointConversion;
         draconicCapacitorMaxUpgrades = getInteger("tweaks.tools", "Draconic Flux Capacitor: Maximum amount of upgrades",
-                                                  draconicCapacitorMaxUpgrades, 0, draconicCapacitorUpgradesLimit);
-        fluxCapacitorMaxUpgradePoints = getInteger("tweaks.tools", "Flux Capacitor: Maximum amount of upgrade points",
-                                                   fluxCapacitorMaxUpgradePoints,
-                                                   Math.max(wyvernCapacitorMaxUpgrades, draconicCapacitorMaxUpgrades) *
-                                                   4, Integer.MAX_VALUE);
+                                                  draconicCapacitorMaxUpgrades, 0,
+                                                  draconicCapacitorMaxCapacityUpgradePoints);
+        draconicCapacitorMaxUpgradePoints =
+            getInteger("tweaks.tools", "Draconic Flux Capacitor: Maximum amount of upgrade points",
+                       draconicCapacitorMaxUpgradePoints, draconicCapacitorMaxUpgrades, Integer.MAX_VALUE);
+        draconicCapacitorMaxCapacityUpgradePoints =
+            Math.max(Math.min(draconicCapacitorMaxUpgradePoints, draconicCapacitorMaxCapacityUpgradePoints), 0);
         grinderShouldUseLooting =
             getBoolean("tweaks.machines", "Mob Grinder: Use Looting enchantment", grinderShouldUseLooting);
         if (config.hasChanged())

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -10,6 +10,10 @@ public class BalanceConfigHandler
     public static int wyvernToolsStoragePerUpgrade = 500000;
     public static int wyvernToolsMaxTransfer = 50000;
     public static int wyvernToolsEnergyPerAction = 80;
+    public static int draconicToolsBaseStorage = 10000000;
+    public static int draconicToolsStoragePerUpgrade = 5000000;
+    public static int draconicToolsMaxTransfer = 500000;
+    public static int draconicToolsEnergyPerAction = 80;
     public static int wyvernCapacitorBaseStorage = 80000000;
     public static int wyvernCapacitorStoragePerUpgrade = 50000000;
     public static int wyvernCapacitorMaxReceive = 1000000;
@@ -40,6 +44,16 @@ public class BalanceConfigHandler
         wyvernToolsEnergyPerAction =
             getInteger("energy.tools", "Wyvern Tools: Amount of energy required to perform action (RF)",
                        wyvernToolsEnergyPerAction);
+        draconicToolsBaseStorage =
+            getInteger("energy.tools", "Draconic Tools: Base energy storage (RF)", draconicToolsBaseStorage);
+        draconicToolsStoragePerUpgrade =
+            getInteger("energy.tools", "Draconic Tools: Additional energy storage per upgrade installed (RF)",
+                       draconicToolsStoragePerUpgrade);
+        draconicToolsMaxTransfer =
+            getInteger("energy.tools", "Draconic Tools: Maximum energy transfer rate (RF/t)", draconicToolsMaxTransfer);
+        draconicToolsEnergyPerAction =
+            getInteger("energy.tools", "Draconic Tools: Amount of energy required to perform action (RF)",
+                       draconicToolsEnergyPerAction);
         wyvernCapacitorBaseStorage =
             getInteger("energy.tools", "Wyvern Flux Capacitor: Base energy storage (RF)", wyvernCapacitorBaseStorage);
         wyvernCapacitorStoragePerUpgrade =

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -6,6 +6,15 @@ import net.minecraftforge.common.config.Configuration;
 
 public class BalanceConfigHandler
 {
+    public static int wyvernArmorBaseStorage = 1000000;
+    public static int wyvernArmorStoragePerUpgrade = 500000;
+    public static int wyvernArmorMaxTransfer = 50000;
+    public static int wyvernArmorEnergyPerProtectionPoint = 1000;
+    public static int draconicArmorBaseStorage = 10000000;
+    public static int draconicArmorStoragePerUpgrade = 5000000;
+    public static int draconicArmorMaxTransfer = 500000;
+    public static int draconicArmorEnergyPerProtectionPoint = 1000;
+    public static int draconicArmorEnergyToRemoveEffects = 5000;
     public static int wyvernToolsBaseStorage = 1000000;
     public static int wyvernToolsStoragePerUpgrade = 500000;
     public static int wyvernToolsMaxTransfer = 50000;
@@ -43,6 +52,29 @@ public class BalanceConfigHandler
     }
     private static void syncConfig()
     {
+        wyvernArmorBaseStorage =
+            getInteger("energy.armor", "Wyvern Armor: Base energy storage (RF)", wyvernArmorBaseStorage);
+        wyvernArmorStoragePerUpgrade =
+            getInteger("energy.armor", "Wyvern Armor: Additional energy storage per upgrade installed (RF)",
+                       wyvernArmorStoragePerUpgrade);
+        wyvernArmorMaxTransfer =
+            getInteger("energy.armor", "Wyvern Armor: Maximum energy transfer rate (RF/t)", wyvernArmorMaxTransfer);
+        wyvernArmorEnergyPerProtectionPoint =
+            getInteger("energy.armor", "Wyvern Armor: Amount of energy required to restore protection point (RF)",
+                       wyvernArmorEnergyPerProtectionPoint);
+        draconicArmorBaseStorage =
+            getInteger("energy.armor", "Draconic Armor: Base energy storage (RF)", draconicArmorBaseStorage);
+        draconicArmorStoragePerUpgrade =
+            getInteger("energy.armor", "Draconic Armor: Additional energy storage per upgrade installed (RF)",
+                       draconicArmorStoragePerUpgrade);
+        draconicArmorMaxTransfer =
+            getInteger("energy.armor", "Draconic Armor: Maximum energy transfer rate (RF/t)", draconicArmorMaxTransfer);
+        draconicArmorEnergyPerProtectionPoint =
+            getInteger("energy.armor", "Draconic Armor: Amount of energy required to restore protection point (RF)",
+                       draconicArmorEnergyPerProtectionPoint);
+        draconicArmorEnergyToRemoveEffects =
+            getInteger("energy.armor", "Draconic Armor: Amount of energy required to remove negative effects (RF)",
+                       draconicArmorEnergyToRemoveEffects);
         wyvernToolsBaseStorage =
             getInteger("energy.tools", "Wyvern Tools: Base energy storage (RF)", wyvernToolsBaseStorage);
         wyvernToolsStoragePerUpgrade =

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/BalanceConfigHandler.java
@@ -46,6 +46,13 @@ public class BalanceConfigHandler
     public static int draconiumBlockChargingSpeed = 10000000;
     public static int energyInfuserStorage = 10000000;
     public static int energyInfuserMaxTransfer = 10000000;
+    public static long energyStorageTier1Storage = 45500000L;
+    public static long energyStorageTier2Storage = 273000000L;
+    public static long energyStorageTier3Storage = 1640000000L;
+    public static long energyStorageTier4Storage = 9880000000L;
+    public static long energyStorageTier5Storage = 59300000000L;
+    public static long energyStorageTier6Storage = 356000000000L;
+    public static long energyStorageTier7Storage = 2140000000000L;
     public static int grinderInternalEnergyBufferSize = 20000;
     public static int grinderExternalEnergyBufferSize = 100000;
     public static int grinderMaxReceive = 32000;
@@ -165,6 +172,27 @@ public class BalanceConfigHandler
             getInteger("energy.machines", "Energy Infuser: Energy buffer size (RF)", energyInfuserStorage);
         energyInfuserMaxTransfer = getInteger("energy.machines", "Energy Infuser: Maximum energy transfer rate (RF/t)",
                                               energyInfuserMaxTransfer);
+        energyStorageTier1Storage =
+            getLong("energy.machines", "Multiblock Energy Storage Tier 1: Energy buffer size (RF)",
+                    energyStorageTier1Storage);
+        energyStorageTier2Storage =
+            getLong("energy.machines", "Multiblock Energy Storage Tier 2: Energy buffer size (RF)",
+                    energyStorageTier2Storage);
+        energyStorageTier3Storage =
+            getLong("energy.machines", "Multiblock Energy Storage Tier 3: Energy buffer size (RF)",
+                    energyStorageTier3Storage);
+        energyStorageTier4Storage =
+            getLong("energy.machines", "Multiblock Energy Storage Tier 4: Energy buffer size (RF)",
+                    energyStorageTier4Storage);
+        energyStorageTier5Storage =
+            getLong("energy.machines", "Multiblock Energy Storage Tier 5: Energy buffer size (RF)",
+                    energyStorageTier5Storage);
+        energyStorageTier6Storage =
+            getLong("energy.machines", "Multiblock Energy Storage Tier 6: Energy buffer size (RF)",
+                    energyStorageTier6Storage);
+        energyStorageTier7Storage =
+            getLong("energy.machines", "Multiblock Energy Storage Tier 7: Energy buffer size (RF)",
+                    energyStorageTier7Storage);
         grinderInternalEnergyBufferSize = getInteger("energy.machines", "Mob Grinder: Internal energy buffer size (RF)",
                                                      grinderInternalEnergyBufferSize);
         grinderExternalEnergyBufferSize =
@@ -188,5 +216,10 @@ public class BalanceConfigHandler
     private static int getInteger(String categoty, String propertyName, int defaultValue)
     {
         return config.get(categoty, propertyName, defaultValue).getInt(defaultValue);
+    }
+    private static long getLong(String category, String propertyName, long defaultValue)
+    {
+        return (long) config.get(category, propertyName, (double) defaultValue, "", 0D, (double) Long.MAX_VALUE)
+                            .getDouble((long) defaultValue);
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
@@ -1,13 +1,13 @@
 package com.brandon3055.draconicevolution.common.handler;
 
-import com.brandon3055.draconicevolution.common.utills.LogHelper;
-import net.minecraftforge.common.config.Configuration;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.brandon3055.draconicevolution.common.utills.LogHelper;
+import net.minecraftforge.common.config.Configuration;
 
 public class ConfigHandler {
 
@@ -77,6 +77,7 @@ public class ConfigHandler {
 	public static void init(File confFile) {
 		if (config == null) {
 			config = new Configuration(confFile);
+			config.load();
 			syncConfig();
 		}
 	}

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
@@ -428,7 +428,7 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_DRACONIC_UPGRADES;
+		return BalanceConfigHandler.draconicArmorMaxUpgrades;
 	}
 
 	@Override
@@ -449,14 +449,20 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.draconicArmorMaxCapacityUpgradePoints;
+		}
+		return BalanceConfigHandler.draconicArmorMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.SHIELD_CAPACITY.index) return (int)(getProtectionShare() * 25) + (armorType == 2 ? 2 : 0);
-		else if (upgradeIndex == EnumUpgrade.SHIELD_RECOVERY.index) return 5;
+		if (upgradeIndex == EnumUpgrade.SHIELD_CAPACITY.index) {
+			return (int)(getProtectionShare() * 25) + (armorType == 2 ? 2 : 0);
+		}
+		if (upgradeIndex == EnumUpgrade.SHIELD_RECOVERY.index) {
+			return BalanceConfigHandler.draconicArmorMinShieldRecovery;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
@@ -456,6 +456,12 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 	}
 
 	@Override
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack)
+	{
+		return getMaxUpgradePoints(upgradeIndex);
+	}
+
+	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.SHIELD_CAPACITY.index) {
 			return (int)(getProtectionShare() * 25) + (armorType == 2 ? 2 : 0);

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
@@ -1,5 +1,9 @@
 package com.brandon3055.draconicevolution.common.items.armor;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import com.brandon3055.brandonscore.BrandonsCore;
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
@@ -9,6 +13,7 @@ import com.brandon3055.draconicevolution.client.model.ModelDraconicArmor;
 import com.brandon3055.draconicevolution.client.model.ModelDraconicArmorOld;
 import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.entity.EntityPersistentItem;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.handler.ConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolBase;
 import com.brandon3055.draconicevolution.common.lib.References;
@@ -42,10 +47,6 @@ import net.minecraftforge.common.ISpecialArmor;
 import thaumcraft.api.IGoggles;
 import thaumcraft.api.nodes.IRevealer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 /**
  * Created by Brandon on 3/07/2014.
  */
@@ -63,8 +64,8 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 	@SideOnly(Side.CLIENT)
 	private IIcon bootsIcon;
 
-	private int maxTransfer = References.DRACONICTRANSFER;
-	private int maxEnergy = References.DRACONICCAPACITY;
+	private int maxEnergy = BalanceConfigHandler.draconicArmorBaseStorage;
+	private int maxTransfer = BalanceConfigHandler.draconicArmorMaxTransfer;
 
 	public DraconicArmor(ArmorMaterial material, int armorType, String name) {
 		super(material, 0, armorType);
@@ -115,6 +116,7 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public IIcon getIconIndex(ItemStack stack) {
 		if (stack.getItem() == ModItems.draconicHelm) return helmIcon;
 		else if (stack.getItem() == ModItems.draconicChest) return chestIcon;
@@ -184,7 +186,10 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 		if (stack == null) return;
 		if (stack.getItem() == ModItems.draconicHelm) {
 			if (world.isRemote) return;
-			if (this.getEnergyStored(stack) >= 5000 && clearNegativeEffects(player)) this.extractEnergy(stack, 5000, false);
+			if (this.getEnergyStored(stack) >= BalanceConfigHandler.draconicArmorEnergyToRemoveEffects && clearNegativeEffects(player))
+			{
+				this.extractEnergy(stack, BalanceConfigHandler.draconicArmorEnergyToRemoveEffects, false);
+			}
 			if (player.worldObj.getBlockLightValue((int)Math.floor(player.posX), (int) player.posY + 1, (int)Math.floor(player.posZ)) < 5 && IConfigurableItem.ProfileHelper.getBoolean(stack, "ArmorNVActive", false))
 			{
 				player.addPotionEffect(new PotionEffect(Potion.nightVision.id, 419, 0, true));
@@ -214,8 +219,13 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 
 				if (player.isBurning()) {
 					player.extinguish();
-					flag = true;
-				} else for (PotionEffect potion : potions) {
+					/*
+					* Wyvern Armor doesn't require energy to extinguish player => Draconic Armor shouldn't require.
+					* See CustomArmorHandler.applyArmorDamageBlocking
+					* */
+					//flag = false;
+				}
+				for (PotionEffect potion : potions) {
 					int id = potion.getPotionID();
 					if (ReflectionHelper.getPrivateValue(Potion.class, Potion.potionTypes[id], new String[]{"isBadEffect", "field_76418_K", "J"})) {
 						if (potion.getPotionID() == Potion.digSlowdown.id && ModHelper.isHoldingCleaver(player)) break;
@@ -248,7 +258,7 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 	public int extractEnergy(ItemStack container, int maxExtract, boolean simulate) {
 
 		int stored = ItemNBTHelper.getInteger(container, "Energy", 0);
-		int extract = Math.min(maxExtract, stored);
+		int extract = Math.min(maxExtract, Math.min(maxTransfer, stored));
 
 		if (!simulate) {
 			stored -= extract;
@@ -264,8 +274,8 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 
 	@Override
 	public int getMaxEnergyStored(ItemStack container) {
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
-		return i * 5000000;
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
+		return BalanceConfigHandler.draconicArmorBaseStorage + points * BalanceConfigHandler.draconicArmorStoragePerUpgrade;
 	}
 
 	/* Misc */
@@ -444,7 +454,7 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.SHIELD_CAPACITY.index) return (int)(getProtectionShare() * 25) + (armorType == 2 ? 2 : 0);
 		else if (upgradeIndex == EnumUpgrade.SHIELD_RECOVERY.index) return 5;
 		return 0;
@@ -510,6 +520,11 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
 			return BrandonsCore.proxy.isCtrlDown() ? IConfigurableItem.ProfileHelper.getFloat(stack, "VerticalAcceleration", 0F) : 0F;
 		}
 		else return IConfigurableItem.ProfileHelper.getFloat(stack, "VerticalAcceleration", 0F);
+	}
+	@Override
+	public int getEnergyPerProtectionPoint()
+	{
+		return BalanceConfigHandler.draconicArmorEnergyPerProtectionPoint;
 	}
 
 	//endregion

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/ICustomArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/ICustomArmor.java
@@ -12,32 +12,35 @@ public interface ICustomArmor extends IEnergyContainerItem {
 	/**Returns the max number of protection points this armor piece can provide
 	 * 1 protection point equals 1 half heart of protection.
 	 * */
-	public float getProtectionPoints(ItemStack stack);
+	float getProtectionPoints(ItemStack stack);
 
-	/**Reruns the number of Upgrade points applied to shield recovery*/
-	public int getRecoveryPoints(ItemStack stack);
+	/**Returns the number of Upgrade points applied to shield recovery*/
+	int getRecoveryPoints(ItemStack stack);
 
 	/**Returns the movement speed modifier for this armor*/
-	public float getSpeedModifier(ItemStack stack, EntityPlayer player);
+	float getSpeedModifier(ItemStack stack, EntityPlayer player);
 
 	/**Returns the jump height modifier for this armor*/
-	public float getJumpModifier(ItemStack stack, EntityPlayer player);
+	float getJumpModifier(ItemStack stack, EntityPlayer player);
 
 	/**Returns true if this armor has up-hill step enabled*/
-	public boolean hasHillStep(ItemStack stack, EntityPlayer player);
+	boolean hasHillStep(ItemStack stack, EntityPlayer player);
 
 	/**Returns the fire resistance modifier for this armor
 	 * This is the percentage of fire damage this armor should absorb
 	 * If the total resistance for all armor peaces the player is wearing is >= 1 the player will not be damaged by fire.
 	 * Should return a number between 0 and 1*/
-	public float getFireResistance(ItemStack stack);
+	float getFireResistance(ItemStack stack);
 
 	/**Returns {true, false} if this armor gives the player flight
 	 * Returns {true, true} if flight lock is also enables on this armor*/
-	public boolean[] hasFlight(ItemStack stack);
+	boolean[] hasFlight(ItemStack stack);
 
-	public float getFlightSpeedModifier(ItemStack stack, EntityPlayer player);
+	float getFlightSpeedModifier(ItemStack stack, EntityPlayer player);
 
 	/**Returns the vertical acceleration speed*/
-	public float getFlightVModifier(ItemStack stack, EntityPlayer player);
+	float getFlightVModifier(ItemStack stack, EntityPlayer player);
+
+	/**Returns amount of energy, required to restore protection point */
+	int getEnergyPerProtectionPoint();
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
@@ -1,5 +1,8 @@
 package com.brandon3055.draconicevolution.common.items.armor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.brandon3055.brandonscore.BrandonsCore;
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
@@ -9,10 +12,14 @@ import com.brandon3055.draconicevolution.client.model.ModelDraconicArmorOld;
 import com.brandon3055.draconicevolution.client.model.ModelWyvernArmor;
 import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.entity.EntityPersistentItem;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.handler.ConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolBase;
 import com.brandon3055.draconicevolution.common.lib.References;
-import com.brandon3055.draconicevolution.common.utills.*;
+import com.brandon3055.draconicevolution.common.utills.IConfigurableItem;
+import com.brandon3055.draconicevolution.common.utills.IInventoryTool;
+import com.brandon3055.draconicevolution.common.utills.IUpgradableItem;
+import com.brandon3055.draconicevolution.common.utills.ItemConfigField;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -31,20 +38,21 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Created by Brandon on 3/07/2014.
  */
 public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurableItem, IInventoryTool, IUpgradableItem, ICustomArmor {
+	@SideOnly(Side.CLIENT)
 	private IIcon helmIcon;
+	@SideOnly(Side.CLIENT)
 	private IIcon chestIcon;
+	@SideOnly(Side.CLIENT)
 	private IIcon leggsIcon;
+	@SideOnly(Side.CLIENT)
 	private IIcon bootsIcon;
 
-	private int maxTransfer = References.WYVERNTRANSFER;
-	private int maxEnergy = References.WYVERNCAPACITY;
+	private int maxEnergy = BalanceConfigHandler.wyvernArmorBaseStorage;
+	private int maxTransfer = BalanceConfigHandler.wyvernArmorMaxTransfer;
 
 	public WyvernArmor(ArmorMaterial material, int armorType, String name) {
 		super(material, 0, armorType);
@@ -95,6 +103,7 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public IIcon getIconIndex(ItemStack stack) {
 		if (stack.getItem() == ModItems.wyvernHelm) return helmIcon;
 		else if (stack.getItem() == ModItems.wyvernChest) return chestIcon;
@@ -198,7 +207,7 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
 	public int extractEnergy(ItemStack container, int maxExtract, boolean simulate) {
 
 		int stored = ItemNBTHelper.getInteger(container, "Energy", 0);
-		int extract = Math.min(maxExtract, stored);
+		int extract = Math.min(maxExtract, Math.min(maxTransfer, stored));
 
 		if (!simulate) {
 			stored -= extract;
@@ -214,8 +223,8 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
 
 	@Override
 	public int getMaxEnergyStored(ItemStack container) {
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
-		return i * 500000;
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
+		return BalanceConfigHandler.wyvernArmorBaseStorage + points * BalanceConfigHandler.wyvernArmorStoragePerUpgrade;
 	}
 
 	@Override
@@ -355,7 +364,7 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.SHIELD_CAPACITY.index) return (int)(getProtectionShare() * 10) + (armorType == 2 ? 1 : 0);
 		else if (upgradeIndex == EnumUpgrade.SHIELD_RECOVERY.index) return 5;
 		return 0;
@@ -411,6 +420,11 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
 	@Override
 	public float getFlightVModifier(ItemStack stack, EntityPlayer player) {
 		return 0;
+	}
+	@Override
+	public int getEnergyPerProtectionPoint()
+	{
+		return BalanceConfigHandler.wyvernArmorEnergyPerProtectionPoint;
 	}
 
 	//endregion

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
@@ -338,7 +338,7 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_WYVERN_UPGRADES;
+		return BalanceConfigHandler.wyvernArmorMaxUpgrades;
 	}
 
 	@Override
@@ -359,14 +359,20 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.wyvernArmorMaxCapacityUpgradePoints;
+		}
+		return BalanceConfigHandler.wyvernArmorMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.SHIELD_CAPACITY.index) return (int)(getProtectionShare() * 10) + (armorType == 2 ? 1 : 0);
-		else if (upgradeIndex == EnumUpgrade.SHIELD_RECOVERY.index) return 5;
+		if (upgradeIndex == EnumUpgrade.SHIELD_CAPACITY.index) {
+			return (int)(getProtectionShare() * 10) + (armorType == 2 ? 1 : 0);
+		}
+		if (upgradeIndex == EnumUpgrade.SHIELD_RECOVERY.index) {
+			return BalanceConfigHandler.wyvernArmorMinShieldRecovery;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
@@ -366,6 +366,12 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
 	}
 
 	@Override
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack)
+	{
+		return getMaxUpgradePoints(upgradeIndex);
+	}
+
+	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.SHIELD_CAPACITY.index) {
 			return (int)(getProtectionShare() * 10) + (armorType == 2 ? 1 : 0);

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicAxe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicAxe.java
@@ -75,7 +75,7 @@ public class DraconicAxe extends MiningTool implements IInventoryTool, IRenderTw
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_DRACONIC_UPGRADES;
+		return BalanceConfigHandler.draconicToolsMaxUpgrades;
 	}
 
 	@Override
@@ -96,18 +96,32 @@ public class DraconicAxe extends MiningTool implements IInventoryTool, IRenderTw
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 4;
-		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 7;
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.draconicToolsMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigDepthUpgradePoints + 2;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigSpeedUpgradePoints;
+		}
+		return BalanceConfigHandler.draconicToolsMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 2;
-		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 1;
-		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 5;
-
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicToolsMinDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) {
+			return BalanceConfigHandler.draconicToolsMinDigDepthUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.draconicToolsMinDigSpeedUpgradePoints;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicAxe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicAxe.java
@@ -1,7 +1,10 @@
 package com.brandon3055.draconicevolution.common.items.tools;
 
+import java.util.List;
+
 import com.brandon3055.draconicevolution.client.render.IRenderTweak;
 import com.brandon3055.draconicevolution.common.ModItems;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.MiningTool;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
@@ -19,18 +22,16 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
-import java.util.List;
-
 public class DraconicAxe extends MiningTool implements IInventoryTool, IRenderTweak {
 
 	public DraconicAxe() {
 		super(ModItems.WYVERN);
 		this.setHarvestLevel("axe", 10);
 		this.setUnlocalizedName(Strings.draconicAxeName);
-		this.setCapacity(References.DRACONICCAPACITY);
-		this.setMaxExtract(References.DRACONICTRANSFER);
-		this.setMaxReceive(References.DRACONICTRANSFER);
-		this.energyPerOperation = References.ENERGYPERBLOCK;
+		this.setCapacity(BalanceConfigHandler.draconicToolsBaseStorage);
+		this.setMaxExtract(BalanceConfigHandler.draconicToolsMaxTransfer);
+		this.setMaxReceive(BalanceConfigHandler.draconicToolsMaxTransfer);
+		this.energyPerOperation = BalanceConfigHandler.draconicToolsEnergyPerAction;
 		ModItems.register(this);
 	}
 
@@ -87,9 +88,10 @@ public class DraconicAxe extends MiningTool implements IInventoryTool, IRenderTw
 		return super.getUpgradeStats(stack);
 	}
 
+	@Override
 	public int getCapacity(ItemStack stack){
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
-		return i * 5000000;
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
+		return BalanceConfigHandler.draconicToolsBaseStorage + points * BalanceConfigHandler.draconicToolsStoragePerUpgrade;
 	}
 
 	@Override
@@ -101,7 +103,7 @@ public class DraconicAxe extends MiningTool implements IInventoryTool, IRenderTw
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 2;
 		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 1;
 		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 5;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicDistructionStaff.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicDistructionStaff.java
@@ -122,7 +122,7 @@ public class DraconicDistructionStaff extends MiningTool implements IInventoryTo
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_STAFF_UPGRADES;
+		return BalanceConfigHandler.draconicStaffMaxUpgrades;
 	}
 
 	@Override
@@ -132,20 +132,38 @@ public class DraconicDistructionStaff extends MiningTool implements IInventoryTo
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 5;
-		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 11;
-		else if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) return 13;
-
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.draconicStaffMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicStaffMaxDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) {
+			return BalanceConfigHandler.draconicStaffMaxDigDepthUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) {
+			return BalanceConfigHandler.draconicStaffMaxAttackAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ATTACK_DAMAGE.index) {
+			return BalanceConfigHandler.draconicStaffMaxAttackDamageUpgradePoints;
+		}
+		return BalanceConfigHandler.draconicStaffMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 3;
-		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 7;
-		else if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) return 3;
-
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicStaffMinDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) {
+			return BalanceConfigHandler.draconicStaffMinDigDepthUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) {
+			return BalanceConfigHandler.draconicStaffMinAttackAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ATTACK_DAMAGE.index) {
+			return BalanceConfigHandler.draconicStaffMinAttackDamageUpgradePoints;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicDistructionStaff.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicDistructionStaff.java
@@ -1,14 +1,18 @@
 package com.brandon3055.draconicevolution.common.items.tools;
 
+import java.util.List;
+
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.draconicevolution.client.render.IRenderTweak;
 import com.brandon3055.draconicevolution.common.ModItems;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.MiningTool;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolHandler;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
 import com.brandon3055.draconicevolution.common.utills.IConfigurableItem;
 import com.brandon3055.draconicevolution.common.utills.IInventoryTool;
+import com.brandon3055.draconicevolution.common.utills.IUpgradableItem;
 import com.brandon3055.draconicevolution.common.utills.ItemConfigField;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -24,8 +28,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
-import java.util.List;
-
 public class DraconicDistructionStaff extends MiningTool implements IInventoryTool, IRenderTweak {
 
 
@@ -35,10 +37,10 @@ public class DraconicDistructionStaff extends MiningTool implements IInventoryTo
 		this.setHarvestLevel("pickaxe", 10);
 		this.setHarvestLevel("shovel", 10);
 		this.setHarvestLevel("axe", 10);
-		this.setCapacity(References.DRACONICCAPACITY * 3);
-		this.setMaxExtract(References.DRACONICTRANSFER * 3);
-		this.setMaxReceive(References.DRACONICTRANSFER * 3);
-		this.energyPerOperation = References.ENERGYPERBLOCK;
+		this.setCapacity(BalanceConfigHandler.draconicToolsBaseStorage * 3);
+		this.setMaxExtract(BalanceConfigHandler.draconicToolsMaxTransfer * 3);
+		this.setMaxReceive(BalanceConfigHandler.draconicToolsMaxTransfer * 3);
+		this.energyPerOperation = BalanceConfigHandler.draconicToolsEnergyPerAction;
 		ModItems.register(this);
 	}
 
@@ -141,10 +143,16 @@ public class DraconicDistructionStaff extends MiningTool implements IInventoryTo
 	public int getBaseUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 3;
 		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 7;
-		else if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 6;
+		else if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) return 3;
 
 		return 0;
+	}
+
+	@Override
+	public int getCapacity(ItemStack stack) {
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
+		return BalanceConfigHandler.draconicToolsBaseStorage * 3 + points * BalanceConfigHandler.draconicToolsStoragePerUpgrade;
 	}
 
 	@Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicDistructionStaff.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicDistructionStaff.java
@@ -8,6 +8,7 @@ import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.MiningTool;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolHandler;
+import com.brandon3055.draconicevolution.common.items.weapons.IEnergyContainerWeaponItem;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
 import com.brandon3055.draconicevolution.common.utills.IConfigurableItem;
@@ -28,8 +29,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
-public class DraconicDistructionStaff extends MiningTool implements IInventoryTool, IRenderTweak {
-
+public class DraconicDistructionStaff extends MiningTool implements IInventoryTool, IRenderTweak, IEnergyContainerWeaponItem {
 
 	public DraconicDistructionStaff() {
 		super(ModItems.CHAOTIC);
@@ -37,9 +37,9 @@ public class DraconicDistructionStaff extends MiningTool implements IInventoryTo
 		this.setHarvestLevel("pickaxe", 10);
 		this.setHarvestLevel("shovel", 10);
 		this.setHarvestLevel("axe", 10);
-		this.setCapacity(BalanceConfigHandler.draconicToolsBaseStorage * 3);
-		this.setMaxExtract(BalanceConfigHandler.draconicToolsMaxTransfer * 3);
-		this.setMaxReceive(BalanceConfigHandler.draconicToolsMaxTransfer * 3);
+		this.setCapacity(BalanceConfigHandler.draconicToolsBaseStorage * 2 + BalanceConfigHandler.draconicWeaponsBaseStorage);
+		this.setMaxExtract(BalanceConfigHandler.draconicToolsMaxTransfer * 2 + BalanceConfigHandler.draconicWeaponsMaxTransfer);
+		this.setMaxReceive(BalanceConfigHandler.draconicToolsMaxTransfer * 2 + BalanceConfigHandler.draconicWeaponsMaxTransfer);
 		this.energyPerOperation = BalanceConfigHandler.draconicToolsEnergyPerAction;
 		ModItems.register(this);
 	}
@@ -152,7 +152,8 @@ public class DraconicDistructionStaff extends MiningTool implements IInventoryTo
 	@Override
 	public int getCapacity(ItemStack stack) {
 		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
-		return BalanceConfigHandler.draconicToolsBaseStorage * 3 + points * BalanceConfigHandler.draconicToolsStoragePerUpgrade;
+		return BalanceConfigHandler.draconicToolsBaseStorage * 2 + BalanceConfigHandler.draconicWeaponsBaseStorage +
+			   points * (BalanceConfigHandler.draconicToolsStoragePerUpgrade + BalanceConfigHandler.draconicWeaponsStoragePerUpgrade);
 	}
 
 	@Override
@@ -170,5 +171,10 @@ public class DraconicDistructionStaff extends MiningTool implements IInventoryTo
 		List<String> list = super.getUpgradeStats(stack);
 		list.add(InfoHelper.ITC()+StatCollector.translateToLocal("info.de.attackDamage.txt")+": "+ InfoHelper.HITC()+ToolHandler.getBaseAttackDamage(stack));
 		return list;
+	}
+	@Override
+	public int getEnergyPerAttack()
+	{
+		return BalanceConfigHandler.draconicWeaponsEnergyPerAttack;
 	}
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicHoe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicHoe.java
@@ -308,6 +308,12 @@ public class DraconicHoe extends ItemHoe implements IEnergyContainerItem, IRende
 	}
 
 	@Override
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack)
+	{
+		return getMaxUpgradePoints(upgradeIndex);
+	}
+
+	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
 			return BalanceConfigHandler.draconicToolsMinDigAOEUpgradePoints + 1;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicHoe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicHoe.java
@@ -288,7 +288,7 @@ public class DraconicHoe extends ItemHoe implements IEnergyContainerItem, IRende
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_DRACONIC_UPGRADES;
+		return BalanceConfigHandler.draconicToolsMaxUpgrades;
 	}
 
 	@Override
@@ -298,16 +298,20 @@ public class DraconicHoe extends ItemHoe implements IEnergyContainerItem, IRende
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 5;
-
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.draconicToolsMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigAOEUpgradePoints + 1;
+		}
+		return BalanceConfigHandler.draconicToolsMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 3;
-
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicToolsMinDigAOEUpgradePoints + 1;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicHoe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicHoe.java
@@ -1,5 +1,8 @@
 package com.brandon3055.draconicevolution.common.items.tools;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import cofh.api.energy.IEnergyContainerItem;
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
@@ -8,6 +11,7 @@ import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.client.render.IRenderTweak;
 import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.entity.EntityPersistentItem;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolBase;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
@@ -35,14 +39,11 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
 import org.lwjgl.opengl.GL11;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class DraconicHoe extends ItemHoe implements IEnergyContainerItem, IRenderTweak, IUpgradableItem, IConfigurableItem, IHudDisplayItem {
 
-	protected int capacity = References.DRACONICCAPACITY;
-	protected int maxReceive = References.DRACONICTRANSFER;
-	protected int maxExtract = References.DRACONICTRANSFER;
+	protected int capacity = BalanceConfigHandler.draconicToolsBaseStorage;
+	protected int maxReceive = BalanceConfigHandler.draconicToolsMaxTransfer;
+	protected int maxExtract = BalanceConfigHandler.draconicToolsMaxTransfer;
 
 	public DraconicHoe() {
 		super(ModItems.WYVERN);
@@ -102,7 +103,7 @@ public class DraconicHoe extends ItemHoe implements IEnergyContainerItem, IRende
 			LogHelper.info(size);
 			for (int x1 = -size; x1 <= size; x1++) {
 				for (int z1 = -size; z1 <= size; z1++) {
-					if (!(stack.getItem() instanceof IEnergyContainerItem) || ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) < References.ENERGYPERBLOCK) {
+					if (!(stack.getItem() instanceof IEnergyContainerItem) || ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) < BalanceConfigHandler.draconicToolsEnergyPerAction) {
 						if (!player.capabilities.isCreativeMode)
 							return false;
 					}
@@ -143,12 +144,12 @@ public class DraconicHoe extends ItemHoe implements IEnergyContainerItem, IRende
 	}
 
 	private boolean hoe(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int par7) {
-		if (!(stack.getItem() instanceof IEnergyContainerItem) || ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) < References.ENERGYPERBLOCK) {
+		if (!(stack.getItem() instanceof IEnergyContainerItem) || ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) < BalanceConfigHandler.draconicToolsEnergyPerAction) {
 			if (!player.capabilities.isCreativeMode)
 				return false;
 		} else {
 			if (!player.capabilities.isCreativeMode)
-				((IEnergyContainerItem) stack.getItem()).extractEnergy(stack, References.ENERGYPERBLOCK, false);
+				((IEnergyContainerItem) stack.getItem()).extractEnergy(stack, BalanceConfigHandler.draconicToolsEnergyPerAction, false);
 		}
 		if (!player.canPlayerEdit(x, y, z, par7, stack)) {
 			return false;
@@ -231,8 +232,8 @@ public class DraconicHoe extends ItemHoe implements IEnergyContainerItem, IRende
 
 	@Override
 	public int getMaxEnergyStored(ItemStack container) {
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
-		return i * 5000000;
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
+		return BalanceConfigHandler.draconicToolsBaseStorage + points * BalanceConfigHandler.draconicToolsStoragePerUpgrade;
 	}
 
 	@Override
@@ -304,7 +305,7 @@ public class DraconicHoe extends ItemHoe implements IEnergyContainerItem, IRende
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 3;
 
 		return 0;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicPickaxe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicPickaxe.java
@@ -1,11 +1,15 @@
 package com.brandon3055.draconicevolution.common.items.tools;
 
+import java.util.List;
+
 import com.brandon3055.draconicevolution.client.render.IRenderTweak;
 import com.brandon3055.draconicevolution.common.ModItems;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.MiningTool;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
 import com.brandon3055.draconicevolution.common.utills.IInventoryTool;
+import com.brandon3055.draconicevolution.common.utills.IUpgradableItem;
 import com.brandon3055.draconicevolution.common.utills.ItemConfigField;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnumEnchantmentType;
@@ -14,8 +18,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
-import java.util.List;
-
 public class DraconicPickaxe extends MiningTool implements IInventoryTool, IRenderTweak {
 
 
@@ -23,10 +25,10 @@ public class DraconicPickaxe extends MiningTool implements IInventoryTool, IRend
 		super(ModItems.AWAKENED);
 		this.setHarvestLevel("pickaxe", 10);
 		this.setUnlocalizedName(Strings.draconicPickaxeName);
-		this.setCapacity(References.DRACONICCAPACITY);
-		this.setMaxExtract(References.DRACONICTRANSFER);
-		this.setMaxReceive(References.DRACONICTRANSFER);
-		this.energyPerOperation = References.ENERGYPERBLOCK;
+		this.setCapacity(BalanceConfigHandler.draconicToolsBaseStorage);
+		this.setMaxExtract(BalanceConfigHandler.draconicToolsMaxTransfer);
+		this.setMaxReceive(BalanceConfigHandler.draconicToolsMaxTransfer);
+		this.energyPerOperation = BalanceConfigHandler.draconicToolsEnergyPerAction;
 		ModItems.register(this);
 	}
 
@@ -90,6 +92,12 @@ public class DraconicPickaxe extends MiningTool implements IInventoryTool, IRend
 	}
 
 	@Override
+	public int getCapacity(ItemStack stack) {
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
+		return BalanceConfigHandler.draconicToolsBaseStorage + points * BalanceConfigHandler.draconicToolsStoragePerUpgrade;
+	}
+
+	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 4;
 		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 5;
@@ -98,7 +106,7 @@ public class DraconicPickaxe extends MiningTool implements IInventoryTool, IRend
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 2;
 		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 1;
 		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 5;
@@ -265,7 +273,7 @@ public class DraconicPickaxe extends MiningTool implements IInventoryTool, IRend
 //
 //	@Override
 //	public float getDigSpeed(ItemStack stack, Block block, int meta) {
-//		if ((stack.getItem() instanceof IEnergyContainerItem) && ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) >= References.ENERGYPERBLOCK)
+//		if ((stack.getItem() instanceof IEnergyContainerItem) && ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) >= energyPerOperation)
 //			return super.getDigSpeed(stack, block, meta);
 //		else
 //			return 1F;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicPickaxe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicPickaxe.java
@@ -78,7 +78,7 @@ public class DraconicPickaxe extends MiningTool implements IInventoryTool, IRend
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_DRACONIC_UPGRADES;
+		return BalanceConfigHandler.draconicToolsMaxUpgrades;
 	}
 
 	@Override
@@ -99,17 +99,32 @@ public class DraconicPickaxe extends MiningTool implements IInventoryTool, IRend
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 4;
-		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 5;
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.draconicToolsMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigDepthUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigSpeedUpgradePoints;
+		}
+		return BalanceConfigHandler.draconicToolsMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 2;
-		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 1;
-		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 5;
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicToolsMinDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) {
+			return BalanceConfigHandler.draconicToolsMinDigDepthUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.draconicToolsMinDigSpeedUpgradePoints;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicShovel.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicShovel.java
@@ -82,7 +82,7 @@ public class DraconicShovel extends MiningTool implements IInventoryTool, IRende
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_DRACONIC_UPGRADES;
+		return BalanceConfigHandler.draconicToolsMaxUpgrades;
 	}
 
 	@Override
@@ -103,19 +103,32 @@ public class DraconicShovel extends MiningTool implements IInventoryTool, IRende
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 4;
-		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 5;
-
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.draconicToolsMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigDepthUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.draconicToolsMaxDigSpeedUpgradePoints;
+		}
+		return BalanceConfigHandler.draconicToolsMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 2;
-		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 1;
-		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 5;
-
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.draconicToolsMinDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) {
+			return BalanceConfigHandler.draconicToolsMinDigDepthUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.draconicToolsMinDigSpeedUpgradePoints;
+		}
 		return 0;
 	}
 //	@Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicShovel.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconicShovel.java
@@ -1,11 +1,15 @@
 package com.brandon3055.draconicevolution.common.items.tools;
 
+import java.util.List;
+
 import com.brandon3055.draconicevolution.client.render.IRenderTweak;
 import com.brandon3055.draconicevolution.common.ModItems;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.MiningTool;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
 import com.brandon3055.draconicevolution.common.utills.IInventoryTool;
+import com.brandon3055.draconicevolution.common.utills.IUpgradableItem;
 import com.brandon3055.draconicevolution.common.utills.ItemConfigField;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnumEnchantmentType;
@@ -14,24 +18,19 @@ import net.minecraft.util.StatCollector;
 import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
-import java.util.List;
-
 public class DraconicShovel extends MiningTool implements IInventoryTool, IRenderTweak {
 //	public IIcon itemIcon0;
 //	public IIcon itemIcon1;
 //	public IIcon itemIcon2;
-	protected int capacity = References.DRACONICCAPACITY;
-	protected int maxReceive = References.DRACONICTRANSFER;
-	protected int maxExtract = References.DRACONICTRANSFER;
 
 	public DraconicShovel() {
 		super(ModItems.AWAKENED);
 		this.setHarvestLevel("shovel", 10);
 		this.setUnlocalizedName(Strings.draconicShovelName);
-		this.setCapacity(References.DRACONICCAPACITY);
-		this.setMaxExtract(References.DRACONICTRANSFER);
-		this.setMaxReceive(References.DRACONICTRANSFER);
-		this.energyPerOperation = References.ENERGYPERBLOCK;
+		this.setCapacity(BalanceConfigHandler.draconicToolsBaseStorage);
+		this.setMaxExtract(BalanceConfigHandler.draconicToolsMaxTransfer);
+		this.setMaxReceive(BalanceConfigHandler.draconicToolsMaxTransfer);
+		this.energyPerOperation = BalanceConfigHandler.draconicToolsEnergyPerAction;
 		ModItems.register(this);
 	}
 
@@ -97,6 +96,12 @@ public class DraconicShovel extends MiningTool implements IInventoryTool, IRende
 	}
 
 	@Override
+	public int getCapacity(ItemStack stack) {
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
+		return BalanceConfigHandler.draconicToolsBaseStorage + points * BalanceConfigHandler.draconicToolsStoragePerUpgrade;
+	}
+
+	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 4;
 		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 5;
@@ -106,7 +111,7 @@ public class DraconicShovel extends MiningTool implements IInventoryTool, IRende
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 2;
 		else if (upgradeIndex == EnumUpgrade.DIG_DEPTH.index) return 1;
 		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 5;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
@@ -12,7 +12,6 @@ import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.RFItemBase;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolBase;
-import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
 import com.brandon3055.draconicevolution.common.utills.IUpgradableItem;
 import cpw.mods.fml.relauncher.Side;
@@ -178,7 +177,10 @@ public class DraconiumFluxCapacitor extends RFItemBase implements IUpgradableIte
 
 	@Override
 	public int getUpgradeCap(ItemStack stack) {
-		return stack.getItemDamage() == 0 ? References.MAX_WYVERN_UPGRADES : References.MAX_DRACONIC_UPGRADES;
+		return stack.getItemDamage() == 0 ?
+			   BalanceConfigHandler.wyvernCapacitorMaxUpgrades :
+			   stack.getItemDamage() == 1 ?
+			   BalanceConfigHandler.draconicCapacitorMaxUpgrades : 0;
 	}
 
 	@Override
@@ -188,7 +190,7 @@ public class DraconiumFluxCapacitor extends RFItemBase implements IUpgradableIte
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		return 50;
+		return BalanceConfigHandler.fluxCapacitorMaxUpgradePoints;
 	}
 
 	@Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
@@ -72,16 +72,16 @@ public class DraconiumFluxCapacitor extends RFItemBase implements IUpgradableIte
 		return super.getUnlocalizedName(itemStack)+itemStack.getItemDamage();
 	}
 
-	@Override
-	public int getCapacity(ItemStack stack){
-		int points = EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
-		return stack.getItemDamage() == 0 ?
-			   BalanceConfigHandler.wyvernCapacitorBaseStorage +
-			   points * BalanceConfigHandler.wyvernCapacitorStoragePerUpgrade :
-			   stack.getItemDamage() == 1 ?
-			   BalanceConfigHandler.draconicCapacitorBaseStorage +
-			   points * BalanceConfigHandler.draconicCapacitorStoragePerUpgrade : 0;
- 	}
+    @Override
+    public int getCapacity(ItemStack stack){
+        int points = EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
+        return stack.getItemDamage() == 0 ?
+               BalanceConfigHandler.wyvernCapacitorBaseStorage +
+               points * BalanceConfigHandler.wyvernCapacitorStoragePerUpgrade :
+               stack.getItemDamage() == 1 ?
+               BalanceConfigHandler.draconicCapacitorBaseStorage +
+               points * BalanceConfigHandler.draconicCapacitorStoragePerUpgrade : 0;
+    }
 
 	@Override
 	 public int getMaxExtract(ItemStack stack){
@@ -136,8 +136,8 @@ public class DraconiumFluxCapacitor extends RFItemBase implements IUpgradableIte
 		return ItemNBTHelper.getShort(stack, "Mode", (short)0) > 0;
 	}
 
-	@Override
-     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+    @Override
+    public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
         if (player.isSneaking()){
             int mode = ItemNBTHelper.getShort(stack, "Mode", (short)0);
             int newMode = mode == 3 ? 0 : mode + 1;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
@@ -190,7 +190,28 @@ public class DraconiumFluxCapacitor extends RFItemBase implements IUpgradableIte
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		return BalanceConfigHandler.fluxCapacitorMaxUpgradePoints;
+		return Math.max(BalanceConfigHandler.wyvernCapacitorMaxUpgradePoints, BalanceConfigHandler.draconicCapacitorMaxUpgradePoints);
+	}
+
+	@Override
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack)
+	{
+		if (stack == null)
+		{
+			return getMaxUpgradePoints(upgradeIndex);
+		}
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return stack.getItemDamage() == 0 ?
+				   BalanceConfigHandler.wyvernCapacitorMaxCapacityUpgradePoints :
+				   stack.getItemDamage() == 1 ?
+				   BalanceConfigHandler.draconicCapacitorMaxCapacityUpgradePoints :
+				   getMaxUpgradePoints(upgradeIndex);
+		}
+		return stack.getItemDamage() == 0 ?
+			   BalanceConfigHandler.wyvernCapacitorMaxUpgradePoints :
+			   stack.getItemDamage() == 1 ?
+			   BalanceConfigHandler.draconicCapacitorMaxUpgradePoints :
+			   getMaxUpgradePoints(upgradeIndex);
 	}
 
 	@Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
@@ -148,8 +148,9 @@ public class DraconiumFluxCapacitor extends RFItemBase implements IUpgradableIte
 		return stack;
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
+	@SideOnly(Side.CLIENT)
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	public void addInformation(final ItemStack stack, final EntityPlayer player, final List list, final boolean extraInformation)
 	{
 		if (InfoHelper.holdShiftForDetails(list)){

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/DraconiumFluxCapacitor.java
@@ -1,15 +1,19 @@
 package com.brandon3055.draconicevolution.common.items.tools;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import cofh.api.energy.IEnergyContainerItem;
+import com.brandon3055.brandonscore.common.utills.InfoHelper;
+import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
 import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.common.ModItems;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.RFItemBase;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolBase;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
-import com.brandon3055.brandonscore.common.utills.InfoHelper;
-import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
 import com.brandon3055.draconicevolution.common.utills.IUpgradableItem;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -23,9 +27,6 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Created by Brandon on 24/11/2014.
@@ -60,9 +61,11 @@ public class DraconiumFluxCapacitor extends RFItemBase implements IUpgradableIte
 	@Override
 	public void getSubItems(Item item, CreativeTabs tab, List list) {
 		list.add(ItemNBTHelper.setInteger(new ItemStack(item, 1, 0), "Energy", 0));
-		list.add(ItemNBTHelper.setInteger(new ItemStack(item, 1, 0), "Energy", 80000000));
+		list.add(ItemNBTHelper.setInteger(new ItemStack(item, 1, 0), "Energy",
+										  BalanceConfigHandler.wyvernCapacitorBaseStorage));
 		list.add(ItemNBTHelper.setInteger(new ItemStack(item, 1, 1), "Energy", 0));
-		list.add(ItemNBTHelper.setInteger(new ItemStack(item, 1, 1), "Energy", 250000000));
+		list.add(ItemNBTHelper.setInteger(new ItemStack(item, 1, 1), "Energy",
+										  BalanceConfigHandler.draconicCapacitorBaseStorage));
 	}
 
 	@Override
@@ -73,17 +76,28 @@ public class DraconiumFluxCapacitor extends RFItemBase implements IUpgradableIte
 	@Override
 	public int getCapacity(ItemStack stack){
 		int points = EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
-		return stack.getItemDamage() == 0 ? 80000000 + points * 50000000 : stack.getItemDamage() == 1 ? 250000000 + points * 50000000 : 0;
+		return stack.getItemDamage() == 0 ?
+			   BalanceConfigHandler.wyvernCapacitorBaseStorage +
+			   points * BalanceConfigHandler.wyvernCapacitorStoragePerUpgrade :
+			   stack.getItemDamage() == 1 ?
+			   BalanceConfigHandler.draconicCapacitorBaseStorage +
+			   points * BalanceConfigHandler.draconicCapacitorStoragePerUpgrade : 0;
  	}
 
 	@Override
 	 public int getMaxExtract(ItemStack stack){
-		return stack.getItemDamage() == 0 ? 10000000 : stack.getItemDamage() == 1 ? 100000000 : 0;
+		return stack.getItemDamage() == 0 ?
+			   BalanceConfigHandler.wyvernCapacitorMaxExtract :
+			   stack.getItemDamage() == 1 ?
+			   BalanceConfigHandler.draconicCapacitorMaxExtract : 0;
 	}
 
 	@Override
 	public int getMaxReceive(ItemStack stack){
-		return stack.getItemDamage() == 0 ? 1000000 : stack.getItemDamage() == 1 ? 10000000 : 0;
+		return stack.getItemDamage() == 0 ?
+			   BalanceConfigHandler.wyvernCapacitorMaxReceive :
+			   stack.getItemDamage() == 1 ?
+			   BalanceConfigHandler.draconicCapacitorMaxReceive: 0;
 	}
 
 	@Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernPickaxe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernPickaxe.java
@@ -76,7 +76,7 @@ public class WyvernPickaxe extends MiningTool implements IInventoryTool, IRender
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_WYVERN_UPGRADES;
+		return BalanceConfigHandler.wyvernToolsMaxUpgrades;
 	}
 
 	@Override
@@ -97,16 +97,26 @@ public class WyvernPickaxe extends MiningTool implements IInventoryTool, IRender
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 2;
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.wyvernToolsMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.wyvernToolsMaxDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.wyvernToolsMaxDigSpeedUpgradePoints;
+		}
+		return BalanceConfigHandler.wyvernToolsMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 1;
-		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 4;
-
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.wyvernToolsMinDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.wyvernToolsMinDigSpeedUpgradePoints;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernPickaxe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernPickaxe.java
@@ -1,7 +1,10 @@
 package com.brandon3055.draconicevolution.common.items.tools;
 
+import java.util.List;
+
 import com.brandon3055.draconicevolution.client.render.IRenderTweak;
 import com.brandon3055.draconicevolution.common.ModItems;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.MiningTool;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
@@ -15,18 +18,16 @@ import net.minecraft.util.StatCollector;
 import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
-import java.util.List;
-
 public class WyvernPickaxe extends MiningTool implements IInventoryTool, IRenderTweak {
 
 	public WyvernPickaxe() {
 		super(ModItems.WYVERN);
 		this.setUnlocalizedName(Strings.wyvernPickaxeName);
 		this.setHarvestLevel("pickaxe", 10);
-		this.setCapacity(References.WYVERNCAPACITY);
-		this.setMaxExtract(References.WYVERNTRANSFER);
-		this.setMaxReceive(References.WYVERNTRANSFER);
-		this.energyPerOperation = References.ENERGYPERBLOCK;
+		this.setCapacity(BalanceConfigHandler.wyvernToolsBaseStorage);
+		this.setMaxExtract(BalanceConfigHandler.wyvernToolsMaxTransfer);
+		this.setMaxReceive(BalanceConfigHandler.wyvernToolsMaxTransfer);
+		this.energyPerOperation = BalanceConfigHandler.wyvernToolsEnergyPerAction;
 		ModItems.register(this);
 	}
 
@@ -90,8 +91,8 @@ public class WyvernPickaxe extends MiningTool implements IInventoryTool, IRender
 
 	@Override
 	public int getCapacity(ItemStack stack){
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
-		return i * 500000;
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
+		return BalanceConfigHandler.wyvernToolsBaseStorage + points * BalanceConfigHandler.wyvernToolsStoragePerUpgrade;
 	}
 
 	@Override
@@ -102,7 +103,7 @@ public class WyvernPickaxe extends MiningTool implements IInventoryTool, IRender
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 1;
 		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 4;
 
@@ -268,7 +269,7 @@ public class WyvernPickaxe extends MiningTool implements IInventoryTool, IRender
 //
 //	@Override
 //	public float getDigSpeed(ItemStack stack, Block block, int meta) {
-//		if ((stack.getItem() instanceof IEnergyContainerItem) && ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) >= References.ENERGYPERBLOCK)
+//		if ((stack.getItem() instanceof IEnergyContainerItem) && ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) >= energyPerOperation)
 //			return super.getDigSpeed(stack, block, meta);
 //		else
 //			return 1F;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernPickaxe.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernPickaxe.java
@@ -90,7 +90,7 @@ public class WyvernPickaxe extends MiningTool implements IInventoryTool, IRender
 	}
 
 	@Override
-	public int getCapacity(ItemStack stack){
+	public int getCapacity(ItemStack stack) {
 		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
 		return BalanceConfigHandler.wyvernToolsBaseStorage + points * BalanceConfigHandler.wyvernToolsStoragePerUpgrade;
 	}

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernShovel.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernShovel.java
@@ -78,7 +78,7 @@ public class WyvernShovel extends MiningTool implements IInventoryTool, IRenderT
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_WYVERN_UPGRADES;
+		return BalanceConfigHandler.wyvernToolsMaxUpgrades;
 	}
 
 	@Override
@@ -98,16 +98,26 @@ public class WyvernShovel extends MiningTool implements IInventoryTool, IRenderT
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 2;
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.wyvernToolsMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.wyvernToolsMaxDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.wyvernToolsMaxDigSpeedUpgradePoints;
+		}
+		return BalanceConfigHandler.wyvernToolsMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 1;
-		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 4;
-
+		if (upgradeIndex == EnumUpgrade.DIG_AOE.index) {
+			return BalanceConfigHandler.wyvernToolsMinDigAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) {
+			return BalanceConfigHandler.wyvernToolsMinDigSpeedUpgradePoints;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernShovel.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernShovel.java
@@ -91,7 +91,7 @@ public class WyvernShovel extends MiningTool implements IInventoryTool, IRenderT
 		return super.getUpgradeStats(stack);
 	}
 
-	public int getCapacity(ItemStack stack){
+	public int getCapacity(ItemStack stack) {
 		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
 		return BalanceConfigHandler.wyvernToolsBaseStorage + points * BalanceConfigHandler.wyvernToolsStoragePerUpgrade;
 	}

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernShovel.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/WyvernShovel.java
@@ -1,7 +1,10 @@
 package com.brandon3055.draconicevolution.common.items.tools;
 
+import java.util.List;
+
 import com.brandon3055.draconicevolution.client.render.IRenderTweak;
 import com.brandon3055.draconicevolution.common.ModItems;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.MiningTool;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
@@ -15,8 +18,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
-import java.util.List;
-
 public class WyvernShovel extends MiningTool implements IInventoryTool, IRenderTweak {
 
 
@@ -24,10 +25,10 @@ public class WyvernShovel extends MiningTool implements IInventoryTool, IRenderT
 		super(ModItems.WYVERN);
 		this.setHarvestLevel("shovel", 10);
 		this.setUnlocalizedName(Strings.wyvernShovelName);
-		this.setCapacity(References.WYVERNCAPACITY);
-		this.setMaxExtract(References.WYVERNTRANSFER);
-		this.setMaxReceive(References.WYVERNTRANSFER);
-		this.energyPerOperation = References.ENERGYPERBLOCK;
+		this.setCapacity(BalanceConfigHandler.wyvernToolsBaseStorage);
+		this.setMaxExtract(BalanceConfigHandler.wyvernToolsMaxTransfer);
+		this.setMaxReceive(BalanceConfigHandler.wyvernToolsMaxTransfer);
+		this.energyPerOperation = BalanceConfigHandler.wyvernToolsEnergyPerAction;
 		ModItems.register(this);
 	}
 
@@ -91,8 +92,8 @@ public class WyvernShovel extends MiningTool implements IInventoryTool, IRenderT
 	}
 
 	public int getCapacity(ItemStack stack){
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
-		return i * 500000;
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
+		return BalanceConfigHandler.wyvernToolsBaseStorage + points * BalanceConfigHandler.wyvernToolsStoragePerUpgrade;
 	}
 
 	@Override
@@ -103,7 +104,7 @@ public class WyvernShovel extends MiningTool implements IInventoryTool, IRenderT
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.DIG_AOE.index) return 1;
 		else if (upgradeIndex == EnumUpgrade.DIG_SPEED.index) return 4;
 
@@ -249,7 +250,7 @@ public class WyvernShovel extends MiningTool implements IInventoryTool, IRenderT
 //
 //	@Override
 //	public float getDigSpeed(ItemStack stack, Block block, int meta) {
-//		if ((stack.getItem() instanceof IEnergyContainerItem) && ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) >= References.ENERGYPERBLOCK)
+//		if ((stack.getItem() instanceof IEnergyContainerItem) && ((IEnergyContainerItem)stack.getItem()).getEnergyStored(stack) >= energyPerOperation)
 //			return super.getDigSpeed(stack, block, meta);
 //		else
 //			return 1F;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/MiningTool.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/MiningTool.java
@@ -293,11 +293,6 @@ public abstract class MiningTool extends ToolBase implements IUpgradableItem {
 		}};
 	}
 
-	public int getCapacity(ItemStack stack){
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
-		return i * 5000000;
-	}
-
 	@Override
 	public float getEfficiency(ItemStack stack) {
 		int i = EnumUpgrade.DIG_SPEED.getUpgradePoints(stack);

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/MiningTool.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/MiningTool.java
@@ -294,6 +294,12 @@ public abstract class MiningTool extends ToolBase implements IUpgradableItem {
 	}
 
 	@Override
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack)
+	{
+		return getMaxUpgradePoints(upgradeIndex);
+	}
+
+	@Override
 	public float getEfficiency(ItemStack stack) {
 		int i = EnumUpgrade.DIG_SPEED.getUpgradePoints(stack);
 		if (i == 0) return super.getEfficiency(stack);

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/MiningTool.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/MiningTool.java
@@ -1,5 +1,10 @@
 package com.brandon3055.draconicevolution.common.items.tools.baseclasses;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
 import com.brandon3055.brandonscore.common.utills.Utills;
@@ -29,11 +34,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.event.world.BlockEvent;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Created by Brandon on 2/01/2015.
@@ -76,7 +76,7 @@ public abstract class MiningTool extends ToolBase implements IUpgradableItem {
 
 	@Override
 	public boolean onBlockDestroyed(ItemStack stack, World p_150894_2_, Block p_150894_3_, int p_150894_4_, int p_150894_5_, int p_150894_6_, EntityLivingBase p_150894_7_) {
-		if (IConfigurableItem.ProfileHelper.getInteger(stack, References.DIG_AOE, 0) == 0) extractEnergy(stack, References.ENERGYPERBLOCK, false);
+		if (IConfigurableItem.ProfileHelper.getInteger(stack, References.DIG_AOE, 0) == 0) extractEnergy(stack, energyPerOperation, false);
 		return super.onBlockDestroyed(stack, p_150894_2_, p_150894_3_, p_150894_4_, p_150894_5_, p_150894_6_, p_150894_7_);
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/RFItemBase.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/RFItemBase.java
@@ -1,5 +1,8 @@
 package com.brandon3055.draconicevolution.common.items.tools.baseclasses;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import cofh.api.energy.IEnergyContainerItem;
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
@@ -7,7 +10,9 @@ import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.common.entity.EntityPersistentItem;
 import com.brandon3055.draconicevolution.common.items.ItemDE;
-import com.brandon3055.draconicevolution.common.utills.*;
+import com.brandon3055.draconicevolution.common.utills.IConfigurableItem;
+import com.brandon3055.draconicevolution.common.utills.IHudDisplayItem;
+import com.brandon3055.draconicevolution.common.utills.ItemConfigField;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.creativetab.CreativeTabs;
@@ -18,18 +23,15 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Created by Brandon on 8/01/2015.
  */
 public class RFItemBase extends ItemDE implements IEnergyContainerItem, IConfigurableItem, IHudDisplayItem {
-	private int capacity = 0;
+	protected int capacity = 0;
 	/**Max Receive*/
-	private int maxReceive = 0;
+	protected int maxReceive = 0;
 	/**Max Extract*/
-	private int maxExtract = 0;
+	protected int maxExtract = 0;
 
 	public RFItemBase(){
 		this.setMaxStackSize(1);

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicBow.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicBow.java
@@ -344,7 +344,7 @@ public class DraconicBow extends ItemBow implements IInventoryTool, IUpgradableI
 	@Override
 	public int getEnergyPerAttack()
 	{
-		return BalanceConfigHandler.draconicWeaponsEnergyPerAttack;
+		return BalanceConfigHandler.draconicBowEnergyPerShot;
 	}
 
 	//endregion

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicBow.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicBow.java
@@ -255,6 +255,12 @@ public class DraconicBow extends ItemBow implements IInventoryTool, IUpgradableI
 	}
 
 	@Override
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack)
+	{
+		return getMaxUpgradePoints(upgradeIndex);
+	}
+
+	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) {
 			return BalanceConfigHandler.draconicBowMinDrawSpeedUpgradePoints;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicBow.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicBow.java
@@ -229,7 +229,7 @@ public class DraconicBow extends ItemBow implements IInventoryTool, IUpgradableI
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_DRACONIC_UPGRADES;
+		return BalanceConfigHandler.draconicBowMaxUpgrades;
 	}
 
 	@Override
@@ -239,17 +239,32 @@ public class DraconicBow extends ItemBow implements IInventoryTool, IUpgradableI
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) return 6;
-		else if (upgradeIndex == EnumUpgrade.ARROW_SPEED.index) return 10;
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.draconicBowMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) {
+			return BalanceConfigHandler.draconicBowMaxDrawSpeedUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_SPEED.index) {
+			return BalanceConfigHandler.draconicBowMaxArrowSpeedUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index) {
+			return BalanceConfigHandler.draconicBowMaxArrowDamageUpgradePoints;
+		}
+		return BalanceConfigHandler.draconicBowMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) return 4;
-		else if (upgradeIndex == EnumUpgrade.ARROW_SPEED.index) return 3;
-		else if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index) return 3;
+		if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) {
+			return BalanceConfigHandler.draconicBowMinDrawSpeedUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_SPEED.index) {
+			return BalanceConfigHandler.draconicBowMinArrowSpeedUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index) {
+			return BalanceConfigHandler.draconicBowMinArrowDamageUpgradePoints;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicSword.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicSword.java
@@ -242,7 +242,7 @@ public class DraconicSword extends ItemSword implements IEnergyContainerWeaponIt
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_DRACONIC_UPGRADES;
+		return BalanceConfigHandler.draconicWeaponsMaxUpgrades;
 	}
 
 	@Override
@@ -252,16 +252,27 @@ public class DraconicSword extends ItemSword implements IEnergyContainerWeaponIt
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) return 5;
-		else if (upgradeIndex == EnumUpgrade.ATTACK_DAMAGE.index) return 12;
-
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.draconicWeaponsMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) {
+			return BalanceConfigHandler.draconicWeaponsMaxAttackAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ATTACK_DAMAGE.index) {
+			return BalanceConfigHandler.draconicWeaponsMaxAttackDamageUpgradePoints;
+		}
+		return BalanceConfigHandler.draconicWeaponsMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) return 2;
+		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) {
+			return BalanceConfigHandler.draconicWeaponsMinAttackAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index)
+		{
+			return BalanceConfigHandler.draconicWeaponsMinAttackDamageUpgradePoints;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicSword.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicSword.java
@@ -265,6 +265,12 @@ public class DraconicSword extends ItemSword implements IEnergyContainerWeaponIt
 	}
 
 	@Override
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack)
+	{
+		return getMaxUpgradePoints(upgradeIndex);
+	}
+
+	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) {
 			return BalanceConfigHandler.draconicWeaponsMinAttackAOEUpgradePoints;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicSword.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/DraconicSword.java
@@ -1,6 +1,8 @@
 package com.brandon3055.draconicevolution.common.items.weapons;
 
-import cofh.api.energy.IEnergyContainerItem;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.brandon3055.brandonscore.BrandonsCore;
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
@@ -9,6 +11,7 @@ import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.client.render.IRenderTweak;
 import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.entity.EntityPersistentItem;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolBase;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolHandler;
 import com.brandon3055.draconicevolution.common.lib.References;
@@ -36,13 +39,10 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public class DraconicSword extends ItemSword implements IEnergyContainerItem, IInventoryTool, IRenderTweak, IUpgradableItem, IHudDisplayItem {
-	protected int capacity = References.DRACONICCAPACITY;
-	protected int maxReceive = References.DRACONICTRANSFER;
-	protected int maxExtract = References.DRACONICTRANSFER * 50;
+public class DraconicSword extends ItemSword implements IEnergyContainerWeaponItem, IInventoryTool, IRenderTweak, IUpgradableItem, IHudDisplayItem {
+	protected int capacity = BalanceConfigHandler.draconicWeaponsBaseStorage;
+	protected int maxReceive = BalanceConfigHandler.draconicWeaponsMaxTransfer;
+	protected int maxExtract = BalanceConfigHandler.draconicWeaponsMaxTransfer;
 
 	public DraconicSword() {
 		super(ModItems.AWAKENED);
@@ -155,8 +155,8 @@ public class DraconicSword extends ItemSword implements IEnergyContainerItem, II
 
 	@Override
 	public int getMaxEnergyStored(ItemStack container) {
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
-		return i * 5000000;
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
+		return BalanceConfigHandler.draconicWeaponsBaseStorage + points * BalanceConfigHandler.draconicWeaponsStoragePerUpgrade;
 	}
 
 	@Override
@@ -260,7 +260,7 @@ public class DraconicSword extends ItemSword implements IEnergyContainerItem, II
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) return 2;
 		return 0;
 	}
@@ -304,5 +304,10 @@ public class DraconicSword extends ItemSword implements IEnergyContainerItem, II
 	@Override
 	public boolean hasProfiles() {
 		return true;
+	}
+	@Override
+	public int getEnergyPerAttack()
+	{
+		return BalanceConfigHandler.draconicWeaponsEnergyPerAttack;
 	}
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/IEnergyContainerWeaponItem.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/IEnergyContainerWeaponItem.java
@@ -1,0 +1,8 @@
+package com.brandon3055.draconicevolution.common.items.weapons;
+
+import cofh.api.energy.IEnergyContainerItem;
+
+public interface IEnergyContainerWeaponItem extends IEnergyContainerItem
+{
+    int getEnergyPerAttack();
+}

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernBow.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernBow.java
@@ -1,6 +1,8 @@
 package com.brandon3055.draconicevolution.common.items.weapons;
 
-import cofh.api.energy.IEnergyContainerItem;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.brandon3055.brandonscore.BrandonsCore;
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
@@ -8,6 +10,7 @@ import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.entity.EntityPersistentItem;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.handler.ConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolBase;
 import com.brandon3055.draconicevolution.common.lib.References;
@@ -33,12 +36,13 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableItem, IEnergyContainerItem, IHudDisplayItem {
+public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableItem, IEnergyContainerWeaponItem, IHudDisplayItem {
 
 	public static final String[] bowPullIconNameArray = new String[] { "pulling_0", "pulling_1", "pulling_2" };
+
+	protected int capacity = BalanceConfigHandler.wyvernWeaponsBaseStorage;
+	protected int maxReceive = BalanceConfigHandler.wyvernWeaponsMaxTransfer;
+	protected int maxExtract = BalanceConfigHandler.wyvernWeaponsMaxTransfer;
 	@SideOnly(Side.CLIENT)
 	private IIcon[] iconArray;
 
@@ -141,7 +145,7 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 	@Override
 	public void getSubItems(Item item, CreativeTabs tab, List list) {
 		list.add(ItemNBTHelper.setInteger(new ItemStack(item, 1, 0), "Energy", 0));
-		list.add(ItemNBTHelper.setInteger(new ItemStack(item, 1, 0), "Energy", 1000000));
+		list.add(ItemNBTHelper.setInteger(new ItemStack(item, 1, 0), "Energy", capacity));
 	}
 
 	@Override
@@ -243,7 +247,7 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) return 3;
 		else if (upgradeIndex == EnumUpgrade.ARROW_SPEED.index) return 1;
 		else if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index) return 2;
@@ -265,8 +269,11 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 	@Override
 	public int receiveEnergy(ItemStack container, int maxReceive, boolean simulate) {
 
+		if (container.stackTagCompound == null || !container.stackTagCompound.hasKey("Energy")) {
+			return 0;
+		}
 		int energy = ItemNBTHelper.getInteger(container, "Energy", 0);
-		int energyReceived = Math.min(getMaxEnergyStored(container) - energy, Math.min(References.WYVERNTRANSFER, maxReceive));
+		int energyReceived = Math.min(getMaxEnergyStored(container) - energy, Math.min(this.maxReceive, maxReceive));
 
 		if (!simulate) {
 			energy += energyReceived;
@@ -278,8 +285,11 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 	@Override
 	public int extractEnergy(ItemStack container, int maxExtract, boolean simulate) {
 
+		if (container.stackTagCompound == null || !container.stackTagCompound.hasKey("Energy")) {
+			return 0;
+		}
 		int energy = ItemNBTHelper.getInteger(container, "Energy", 0);
-		int energyExtracted = Math.min(energy, maxExtract);
+		int energyExtracted = Math.min(energy, Math.min(this.maxExtract, maxExtract));
 
 		if (!simulate) {
 			energy -= energyExtracted;
@@ -295,8 +305,8 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 
 	@Override
 	public int getMaxEnergyStored(ItemStack stack) {
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
-		return i * 500000;
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(stack);
+		return BalanceConfigHandler.wyvernWeaponsBaseStorage + points * BalanceConfigHandler.wyvernWeaponsStoragePerUpgrade;
 	}
 
 	@Override
@@ -327,6 +337,11 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 
 		}
 		return list;
+	}
+	@Override
+	public int getEnergyPerAttack()
+	{
+		return BalanceConfigHandler.wyvernWeaponsEnergyPerAttack;
 	}
 	//endregion
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernBow.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernBow.java
@@ -230,7 +230,7 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_WYVERN_UPGRADES;
+		return BalanceConfigHandler.wyvernBowMaxUpgrades;
 	}
 
 	@Override
@@ -240,17 +240,32 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) return 5;
-		else if (upgradeIndex == EnumUpgrade.ARROW_SPEED.index) return 10;
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.wyvernBowMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) {
+			return BalanceConfigHandler.wyvernBowMaxDrawSpeedUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_SPEED.index) {
+			return BalanceConfigHandler.wyvernBowMaxArrowSpeedUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index) {
+			return BalanceConfigHandler.wyvernBowMaxArrowDamageUpgradePoints;
+		}
+		return BalanceConfigHandler.wyvernBowMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) return 3;
-		else if (upgradeIndex == EnumUpgrade.ARROW_SPEED.index) return 1;
-		else if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index) return 2;
+		if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) {
+			return BalanceConfigHandler.wyvernBowMinDrawSpeedUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_SPEED.index) {
+			return BalanceConfigHandler.wyvernBowMinArrowSpeedUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index) {
+			return BalanceConfigHandler.wyvernBowMinArrowDamageUpgradePoints;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernBow.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernBow.java
@@ -256,6 +256,12 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 	}
 
 	@Override
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack)
+	{
+		return getMaxUpgradePoints(upgradeIndex);
+	}
+
+	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.DRAW_SPEED.index) {
 			return BalanceConfigHandler.wyvernBowMinDrawSpeedUpgradePoints;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernBow.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernBow.java
@@ -341,7 +341,7 @@ public class WyvernBow extends ItemBow implements IInventoryTool, IUpgradableIte
 	@Override
 	public int getEnergyPerAttack()
 	{
-		return BalanceConfigHandler.wyvernWeaponsEnergyPerAttack;
+		return BalanceConfigHandler.wyvernBowEnergyPerShot;
 	}
 	//endregion
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernSword.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernSword.java
@@ -271,6 +271,12 @@ public class WyvernSword extends ItemSword implements IEnergyContainerWeaponItem
 	}
 
 	@Override
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack)
+	{
+		return getMaxUpgradePoints(upgradeIndex);
+	}
+
+	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
 		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) {
 			return BalanceConfigHandler.wyvernWeaponsMinAttackAOEUpgradePoints;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernSword.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernSword.java
@@ -247,7 +247,7 @@ public class WyvernSword extends ItemSword implements IEnergyContainerWeaponItem
 
 	@Override
 	public int getUpgradeCap(ItemStack itemstack) {
-		return References.MAX_WYVERN_UPGRADES;
+		return BalanceConfigHandler.wyvernWeaponsMaxUpgrades;
 	}
 
 	@Override
@@ -257,16 +257,27 @@ public class WyvernSword extends ItemSword implements IEnergyContainerWeaponItem
 
 	@Override
 	public int getMaxUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) return 3;
-
-		return 50;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) {
+			return BalanceConfigHandler.wyvernWeaponsMaxCapacityUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) {
+			return BalanceConfigHandler.wyvernWeaponsMaxAttackAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index)
+		{
+			return BalanceConfigHandler.wyvernWeaponsMaxAttackDamageUpgradePoints;
+		}
+		return BalanceConfigHandler.wyvernWeaponsMaxUpgradePoints;
 	}
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
-		else if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) return 1;
-
+		if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) {
+			return BalanceConfigHandler.wyvernWeaponsMinAttackAOEUpgradePoints;
+		}
+		if (upgradeIndex == EnumUpgrade.ARROW_DAMAGE.index) {
+			return BalanceConfigHandler.wyvernWeaponsMinAttackDamageUpgradePoints;
+		}
 		return 0;
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernSword.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/weapons/WyvernSword.java
@@ -1,6 +1,8 @@
 package com.brandon3055.draconicevolution.common.items.weapons;
 
-import cofh.api.energy.IEnergyContainerItem;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.brandon3055.brandonscore.BrandonsCore;
 import com.brandon3055.brandonscore.common.utills.InfoHelper;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
@@ -9,6 +11,7 @@ import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.client.render.IRenderTweak;
 import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.entity.EntityPersistentItem;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolBase;
 import com.brandon3055.draconicevolution.common.items.tools.baseclasses.ToolHandler;
 import com.brandon3055.draconicevolution.common.lib.References;
@@ -37,14 +40,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
-import java.util.ArrayList;
-import java.util.List;
+public class WyvernSword extends ItemSword implements IEnergyContainerWeaponItem, IInventoryTool, IRenderTweak, IUpgradableItem, IHudDisplayItem{
 
-public class WyvernSword extends ItemSword implements IEnergyContainerItem, IInventoryTool, IRenderTweak, IUpgradableItem, IHudDisplayItem{
-
-	protected int capacity = References.WYVERNCAPACITY;
-	protected int maxReceive = References.WYVERNTRANSFER;
-	protected int maxExtract = References.WYVERNTRANSFER;
+	protected int capacity = BalanceConfigHandler.wyvernWeaponsBaseStorage;
+	protected int maxReceive = BalanceConfigHandler.wyvernWeaponsMaxTransfer;
+	protected int maxExtract = BalanceConfigHandler.wyvernWeaponsMaxTransfer;
 
 	public WyvernSword() {
 		super(ModItems.WYVERN);
@@ -164,8 +164,8 @@ public class WyvernSword extends ItemSword implements IEnergyContainerItem, IInv
 
 	@Override
 	public int getMaxEnergyStored(ItemStack container) {
-		int i = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
-		return i * 500000;
+		int points = IUpgradableItem.EnumUpgrade.RF_CAPACITY.getUpgradePoints(container);
+		return BalanceConfigHandler.wyvernWeaponsBaseStorage + points * BalanceConfigHandler.wyvernWeaponsStoragePerUpgrade;
 	}
 
 	@Override
@@ -264,7 +264,7 @@ public class WyvernSword extends ItemSword implements IEnergyContainerItem, IInv
 
 	@Override
 	public int getBaseUpgradePoints(int upgradeIndex) {
-		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 2;
+		if (upgradeIndex == EnumUpgrade.RF_CAPACITY.index) return 0;
 		else if (upgradeIndex == EnumUpgrade.ATTACK_AOE.index) return 1;
 
 		return 0;
@@ -309,6 +309,11 @@ public class WyvernSword extends ItemSword implements IEnergyContainerItem, IInv
 	@Override
 	public boolean hasProfiles() {
 		return true;
+	}
+	@Override
+	public int getEnergyPerAttack()
+	{
+		return BalanceConfigHandler.wyvernWeaponsEnergyPerAttack;
 	}
 }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
@@ -15,7 +15,6 @@ public final class References {
 
 	public static final int MAX_WYVERN_UPGRADES = 3;
 	public static final int MAX_DRACONIC_UPGRADES = 6;
-	public static final int MAX_STAFF_UPGRADES = 12;
 
 	//======================Render IDs========================//
 	public static int idTeleporterStand	= -1;

--- a/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
@@ -16,7 +16,6 @@ public final class References {
 	public static final int WYVERNTRANSFER 		= 50000;
 	public static final int DRACONICCAPACITY 	= 10000000;
 	public static final int DRACONICTRANSFER 	= 500000;
-	public static final int ENERGYPERATTACK 	= 250;
 
 	public static final int MAX_WYVERN_UPGRADES = 3;
 	public static final int MAX_DRACONIC_UPGRADES = 6;

--- a/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
@@ -12,10 +12,6 @@ public final class References {
 
 
 	//======================Tools & Weapons========================//
-	public static final int WYVERNCAPACITY 		= 1000000;
-	public static final int WYVERNTRANSFER 		= 50000;
-	public static final int DRACONICCAPACITY 	= 10000000;
-	public static final int DRACONICTRANSFER 	= 500000;
 
 	public static final int MAX_WYVERN_UPGRADES = 3;
 	public static final int MAX_DRACONIC_UPGRADES = 6;

--- a/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
@@ -10,12 +10,6 @@ public final class References {
 	public static final String GUIFACTORY 			= "com.brandon3055.draconicevolution.client.gui.DEGUIFactory";
 	public static final String RESOURCESPREFIX 		= MODID.toLowerCase() + ":";
 
-
-	//======================Tools & Weapons========================//
-
-	public static final int MAX_WYVERN_UPGRADES = 3;
-	public static final int MAX_DRACONIC_UPGRADES = 6;
-
 	//======================Render IDs========================//
 	public static int idTeleporterStand	= -1;
 	public static int idPortal		 	= -1;

--- a/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/lib/References.java
@@ -16,7 +16,6 @@ public final class References {
 	public static final int WYVERNTRANSFER 		= 50000;
 	public static final int DRACONICCAPACITY 	= 10000000;
 	public static final int DRACONICTRANSFER 	= 500000;
-	public static final int ENERGYPERBLOCK 		= 80;
 	public static final int ENERGYPERATTACK 	= 250;
 
 	public static final int MAX_WYVERN_UPGRADES = 3;

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileEnergyInfuser.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileEnergyInfuser.java
@@ -1,9 +1,12 @@
 package com.brandon3055.draconicevolution.common.tileentities;
 
+import java.util.Random;
+
 import cofh.api.energy.IEnergyContainerItem;
 import cofh.api.energy.IEnergyReceiver;
 import com.brandon3055.draconicevolution.client.handler.ParticleHandler;
 import com.brandon3055.draconicevolution.client.render.particle.ParticleEnergy;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.utills.EnergyStorage;
 import cpw.mods.fml.relauncher.Side;
@@ -17,15 +20,12 @@ import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.Random;
-
 /**
  * Created by Brandon on 27/06/2014.
  */
 public class TileEnergyInfuser extends TileObjectSync implements IEnergyReceiver, ISidedInventory {
 	ItemStack[] items = new ItemStack[1];
-	public EnergyStorage energy = new EnergyStorage(10000000);
-	public int maxInput = 10000000;
+	public EnergyStorage energy = new EnergyStorage(BalanceConfigHandler.energyInfuserStorage, BalanceConfigHandler.energyInfuserMaxTransfer);
 	public boolean running = false;
 	public boolean runningCach = false;
 	private int tick = 0;
@@ -38,14 +38,16 @@ public class TileEnergyInfuser extends TileObjectSync implements IEnergyReceiver
 
 	@Override
 	public void updateEntity() {
-		if (worldObj.isRemote && running) {
-			rotation += 0.5F;
-			if (rotation > 360F) rotation = 0;
-			spawnParticles();
+		if (worldObj.isRemote) {
+			if (running) {
+				rotation += 0.5F;
+				if (rotation > 360F) {
+					rotation = 0;
+				}
+				spawnParticles();
+			}
 			return;
 		}
-
-		if(worldObj.isRemote) return;
 
 		if (tick % 100 == 0) tryStartOrStop();
 		if (tick % 400 == 0) detectAndSendChanges(true);
@@ -136,7 +138,7 @@ public class TileEnergyInfuser extends TileObjectSync implements IEnergyReceiver
 
 	@Override
 	public int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate) {
-		return this.energy.receiveEnergy(Math.min(maxInput, maxReceive), simulate);
+		return this.energy.receiveEnergy(maxReceive, simulate);
 	}
 
 	@Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
@@ -97,8 +97,12 @@ public class TileEnergyStorageCore extends TileObjectSync {
 				for (int z = zCoord - 1; z <= zCoord + 1; z++) {
 					if (worldObj.getBlock(x, y, z) == ModBlocks.invisibleMultiblock)
 					{
-						if (worldObj.getBlockMetadata(x, y, z) == 0) worldObj.setBlock(x, y, z, ModBlocks.draconiumBlock);
-						else if (worldObj.getBlockMetadata(x, y, z) == 1) worldObj.setBlock(x, y, z, Blocks.redstone_block);
+						if (worldObj.getBlockMetadata(x, y, z) == 0) {
+							worldObj.setBlock(x, y, z, ModBlocks.draconiumBlock);
+						}
+						else if (worldObj.getBlockMetadata(x, y, z) == 1) {
+							worldObj.setBlock(x, y, z, BalanceConfigHandler.energyStorageStructureBlock, BalanceConfigHandler.energyStorageStructureBlockMetadata, 3);
+						}
 					}
 				}
 			}
@@ -544,9 +548,12 @@ public class TileEnergyStorageCore extends TileObjectSync {
 	private boolean testForOrActivateRedstone(int x, int y, int z, boolean set, boolean activate){
 		if (!activate) {
 			if (set) {
-				worldObj.setBlock(x, y, z, Blocks.redstone_block);
+				worldObj.setBlock(x, y, z, BalanceConfigHandler.energyStorageStructureBlock, BalanceConfigHandler.energyStorageStructureBlockMetadata, 3);
 				return true;
-			} else return worldObj.getBlock(x, y, z) == Blocks.redstone_block || (worldObj.getBlock(x, y, z) == ModBlocks.invisibleMultiblock && worldObj.getBlockMetadata(x, y, z) == 1);
+			} else {
+				return (worldObj.getBlock(x, y, z) == BalanceConfigHandler.energyStorageStructureBlock && worldObj.getBlockMetadata(x, y, z) == BalanceConfigHandler.energyStorageStructureBlockMetadata) ||
+					   (worldObj.getBlock(x, y, z) == ModBlocks.invisibleMultiblock && worldObj.getBlockMetadata(x, y, z) == 1);
+			}
 		}else{
 			return activateRedstone(x, y, z);
 		}

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
@@ -2,6 +2,7 @@ package com.brandon3055.draconicevolution.common.tileentities.multiblocktiles;
 
 import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper.TileLocation;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.tileentities.TileObjectSync;
 import com.brandon3055.draconicevolution.common.tileentities.TileParticleGenerator;
@@ -606,28 +607,33 @@ public class TileEnergyStorageCore extends TileObjectSync {
 			tile.setMaster(new TileLocation(xCoord, yCoord, zCoord));
 			worldObj.setBlockMetadataWithNotify(stabilizers[i].getXCoord(), stabilizers[i].getYCoord(), stabilizers[i].getZCoord(), 1, 2);
 		}
+		initializeCapacity();
+	}
+
+	private void initializeCapacity()
+	{
 		long capacity = 0;
 		switch (tier){
 			case 0:
-				capacity = 45500000L;
+				capacity = BalanceConfigHandler.energyStorageTier1Storage;
 				break;
 			case 1:
-				capacity = 273000000L;
+				capacity = BalanceConfigHandler.energyStorageTier2Storage;
 				break;
 			case 2:
-				capacity = 1640000000L;
+				capacity = BalanceConfigHandler.energyStorageTier3Storage;
 				break;
 			case 3:
-				capacity = 9880000000L;
+				capacity = BalanceConfigHandler.energyStorageTier4Storage;
 				break;
 			case 4:
-				capacity = 59300000000L;
+				capacity = BalanceConfigHandler.energyStorageTier5Storage;
 				break;
 			case 5:
-				capacity = 356000000000L;
+				capacity = BalanceConfigHandler.energyStorageTier6Storage;
 				break;
 			case 6:
-				capacity = 2140000000000L;
+				capacity = BalanceConfigHandler.energyStorageTier7Storage;
 				break;
 		}
 		this.capacity = capacity;
@@ -710,32 +716,7 @@ public class TileEnergyStorageCore extends TileObjectSync {
 			if (stabilizers[i] != null)
 				stabilizers[i].readFromNBT(compound, String.valueOf(i));
 		}
-		long capacity = 0;
-		switch (tier){
-			case 0:
-				capacity = 45500000L;//000
-				break;
-			case 1:
-				capacity = 273000000L;//000
-				break;
-			case 2:
-				capacity = 1640000000L;//000
-				break;
-			case 3:
-				capacity = 9880000000L;//000
-				break;
-			case 4:
-				capacity = 59300000000L;//000
-				break;
-			case 5:
-				capacity = 356000000000L;//000
-				break;
-			case 6:
-				capacity = 2140000000000L;//000
-				break;
-		}
-		this.capacity = capacity;
-		if (energy > capacity) energy = capacity;
+		initializeCapacity();
 		super.readFromNBT(compound);
 	}
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileInvisibleMultiblock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileInvisibleMultiblock.java
@@ -2,8 +2,8 @@ package com.brandon3055.draconicevolution.common.tileentities.multiblocktiles;
 
 import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper.TileLocation;
+import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.utills.LogHelper;
-import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
@@ -75,6 +75,6 @@ public class TileInvisibleMultiblock extends TileEntity {
 		if (meta == 0)
 			worldObj.setBlock(xCoord, yCoord, zCoord, ModBlocks.draconiumBlock);
 		else if (meta == 1)
-			worldObj.setBlock(xCoord, yCoord, zCoord, Blocks.redstone_block);
+			worldObj.setBlock(xCoord, yCoord, zCoord, BalanceConfigHandler.energyStorageStructureBlock, BalanceConfigHandler.energyStorageStructureBlockMetadata, 3);
 	}
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/utills/IUpgradableItem.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/utills/IUpgradableItem.java
@@ -1,13 +1,13 @@
 package com.brandon3055.draconicevolution.common.utills;
 
+import java.util.List;
+
 import cofh.api.energy.IEnergyContainerItem;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
 import com.brandon3055.draconicevolution.common.lib.References;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.StatCollector;
-
-import java.util.List;
 
 /**
  * Created by brandon3055 on 23/12/2015.
@@ -28,6 +28,8 @@ public interface IUpgradableItem {
 	public int getMaxTier(ItemStack itemstack);
 
 	public int getMaxUpgradePoints(int upgradeIndex);
+
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack);
 
 	public int getBaseUpgradePoints(int upgradeIndex);
 
@@ -174,7 +176,7 @@ public interface IUpgradableItem {
 			int totalPoints = applied[0] + (applied[1] * 2) + (applied[2] * 4) + (applied[3] * 8);
 			if (itemStack != null && itemStack.getItem() instanceof IUpgradableItem){
 				int points = ((IUpgradableItem)itemStack.getItem()).getBaseUpgradePoints(index) + (totalPoints / pointConversion);
-				return Math.min(points, ((IUpgradableItem)itemStack.getItem()).getMaxUpgradePoints(index));
+				return Math.min(points, ((IUpgradableItem)itemStack.getItem()).getMaxUpgradePoints(index, itemStack));
 			}
 			return 0;
 		}

--- a/src/main/java/com/brandon3055/draconicevolution/common/utills/IUpgradableItem.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/utills/IUpgradableItem.java
@@ -13,187 +13,6 @@ import net.minecraft.util.StatCollector;
  * Created by brandon3055 on 23/12/2015.
  */
 public interface IUpgradableItem {
-
-<<<<<<< HEAD
-	/**@return a list of upgrades for this item.*/
-	public List<EnumUpgrade> getUpgrades(ItemStack itemstack);
-
-	/**@return the maximum number of upgrades for this item*/
-	public int getUpgradeCap(ItemStack itemstack);
-
-	/**@return the max upgrade tier allowed for this item
-	 * 0 = Draconic Core
-	 * 1 = Wyvern Core
-	 * 2 = Awakened Core
-	 * 3 = Chaotic Core*/
-	public int getMaxTier(ItemStack itemstack);
-
-	public int getMaxUpgradePoints(int upgradeIndex);
-
-	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack);
-
-	public int getBaseUpgradePoints(int upgradeIndex);
-
-	public List<String> getUpgradeStats(ItemStack itemstack);
-
-	public static enum EnumUpgrade {
-		RF_CAPACITY		(0, 1, "RFCapacity"){
-			@Override
-			public void onRemovedFromItem(ItemStack itemStack) {
-				if (itemStack != null && itemStack.getItem() instanceof IEnergyContainerItem){
-					IEnergyContainerItem item = (IEnergyContainerItem)itemStack.getItem();
-					for (int i = 0; i < 500 && item.getEnergyStored(itemStack) > item.getMaxEnergyStored(itemStack); i++){
-						item.extractEnergy(itemStack, item.getEnergyStored(itemStack)-item.getMaxEnergyStored(itemStack), false);
-					}
-				}
-			}
-		},
-		DIG_SPEED		(1,  1, "DigSpeed"),
-		DIG_AOE			(2,  4, "DigAOE"){
-			@Override
-			public void onRemovedFromItem(ItemStack itemStack) {
-				int profile = ItemNBTHelper.getInteger(itemStack, "ConfigProfile", 0);
-
-				for (int i = 0; i < 5; i++){
-					ItemNBTHelper.setInteger(itemStack, "ConfigProfile", i);
-					if (IConfigurableItem.ProfileHelper.getInteger(itemStack, References.DIG_AOE, 0) > getUpgradePoints(itemStack)) IConfigurableItem.ProfileHelper.setInteger(itemStack, References.DIG_AOE, getUpgradePoints(itemStack));
-				}
-
-				ItemNBTHelper.setInteger(itemStack, "ConfigProfile", profile);
-			}
-		},
-		DIG_DEPTH		(3,  2, "DigDepth"){
-			@Override
-			public void onRemovedFromItem(ItemStack itemStack) {
-				int profile = ItemNBTHelper.getInteger(itemStack, "ConfigProfile", 0);
-
-				for (int i = 0; i < 5; i++){
-					ItemNBTHelper.setInteger(itemStack, "ConfigProfile", i);
-					if (IConfigurableItem.ProfileHelper.getInteger(itemStack, References.DIG_DEPTH, 0) > getUpgradePoints(itemStack)) IConfigurableItem.ProfileHelper.setInteger(itemStack, References.DIG_DEPTH, getUpgradePoints(itemStack));
-				}
-
-				ItemNBTHelper.setInteger(itemStack, "ConfigProfile", profile);
-			}
-		},
-		ATTACK_DAMAGE	(4,  1, "AttackDamage"),
-		ATTACK_AOE		(5,  2, "AttackAOE"){
-			@Override
-			public void onRemovedFromItem(ItemStack itemStack) {
-				int profile = ItemNBTHelper.getInteger(itemStack, "ConfigProfile", 0);
-
-				for (int i = 0; i < 5; i++){
-					ItemNBTHelper.setInteger(itemStack, "ConfigProfile", i);
-					if (IConfigurableItem.ProfileHelper.getInteger(itemStack, References.ATTACK_AOE, 0) > getUpgradePoints(itemStack)) IConfigurableItem.ProfileHelper.setInteger(itemStack, References.ATTACK_AOE, getUpgradePoints(itemStack));
-				}
-
-				ItemNBTHelper.setInteger(itemStack, "ConfigProfile", profile);
-			}
-		},
-		ARROW_DAMAGE	(6,  1, "ArrowDamage"){
-			@Override
-			public void onRemovedFromItem(ItemStack itemStack) {
-				int profile = ItemNBTHelper.getInteger(itemStack, "ConfigProfile", 0);
-
-				for (int i = 0; i < 5; i++){
-					ItemNBTHelper.setInteger(itemStack, "ConfigProfile", i);
-					if (IConfigurableItem.ProfileHelper.getInteger(itemStack, "BowArrowDamage", 0) > getUpgradePoints(itemStack)) IConfigurableItem.ProfileHelper.setInteger(itemStack, "BowArrowDamage", getUpgradePoints(itemStack));
-				}
-
-				ItemNBTHelper.setInteger(itemStack, "ConfigProfile", profile);
-			}
-		},
-		DRAW_SPEED		(7,  2, "DrawSpeed"),
-		ARROW_SPEED		(8,  2, "ArrowSpeed"){
-			@Override
-			public void onRemovedFromItem(ItemStack itemStack) {
-				int profile = ItemNBTHelper.getInteger(itemStack, "ConfigProfile", 0);
-
-				for (int i = 0; i < 5; i++){
-					ItemNBTHelper.setInteger(itemStack, "ConfigProfile", i);
-					if (IConfigurableItem.ProfileHelper.getInteger(itemStack, "BowArrowSpeedModifier", 0) > getUpgradePoints(itemStack)) IConfigurableItem.ProfileHelper.setInteger(itemStack, "BowArrowSpeedModifier", getUpgradePoints(itemStack));
-				}
-
-				ItemNBTHelper.setInteger(itemStack, "ConfigProfile", profile);
-			}
-		},
-		SHIELD_CAPACITY	(9,  1, "ShieldCapacity"),
-		SHIELD_RECOVERY	(10, 1, "ShieldRecovery"),
-		MOVE_SPEED		(11, 1, "MoveSpeed"),
-		JUMP_BOOST		(12, 1, "JumpBoost");
-
-		public int index;
-		/**How many core points dose it take to add 1 upgrade point*/
-		public int pointConversion;
-		public String name;
-		private final String COMPOUND_NAME =  "Upgrades";
-
-		private EnumUpgrade(int index, int pointConversion, String name) {
-			this.index = index;
-			this.pointConversion = pointConversion;
-			this.name = name;
-		}
-
-		/**Get the number of cores applied to this upgrade
-		 * @return an int[4] containing the number of cores that have been applied
-		 * in order from index 0 which is the number od draconic cores to index 3 which is the number of chaotic cores
-		 * with wyvern and awakened in between*/
-		public int[] getCoresApplied(ItemStack stack){
-			if (stack == null) return new int[] {0, 0, 0, 0};
-			NBTTagCompound compound = ItemNBTHelper.getCompound(stack);
-			if (!compound.hasKey(COMPOUND_NAME)) return new int[] {0, 0, 0, 0};
-			NBTTagCompound upgrades = compound.getCompoundTag(COMPOUND_NAME);
-			if (upgrades.hasKey(name) && upgrades.getIntArray(name).length == 4) return upgrades.getIntArray(name);
-			return new int[] {0, 0, 0, 0};
-		}
-
-		/**Sets the number of each core type applied
-		 * takes an ItemStack and an int[4]*/
-		public void setCoresApplied(ItemStack stack, int[] cores){
-			if (cores.length != 4){
-				LogHelper.error("[EnumUpgrade] Error applying upgrades to stack.");
-				return;
-			}
-
-			NBTTagCompound compound = ItemNBTHelper.getCompound(stack);
-			NBTTagCompound upgrades;
-			if (compound.hasKey(COMPOUND_NAME)) upgrades = compound.getCompoundTag(COMPOUND_NAME);
-			else upgrades = new NBTTagCompound();
-			upgrades.setIntArray(name, cores);
-			compound.setTag(COMPOUND_NAME, upgrades);
-		}
-
-		public String getLocalizedName() { return StatCollector.translateToLocal("gui.de."+name+".txt"); }
-
-		public static EnumUpgrade getUpgradeByIndex(int index) {
-			for (EnumUpgrade upgrade : EnumUpgrade.values()) {
-				if (upgrade.index == index) return upgrade;
-			}
-			return null;
-		}
-
-		/**Returns the combined upgrade points from all cores applied to this upgrade */
-		public int getUpgradePoints(ItemStack itemStack){
-			int[] applied = getCoresApplied(itemStack);
-			int totalPoints = applied[0] + (applied[1] * 2) + (applied[2] * 4) + (applied[3] * 8);
-			if (itemStack != null && itemStack.getItem() instanceof IUpgradableItem){
-				int points = ((IUpgradableItem)itemStack.getItem()).getBaseUpgradePoints(index) + (totalPoints / pointConversion);
-				return Math.min(points, ((IUpgradableItem)itemStack.getItem()).getMaxUpgradePoints(index, itemStack));
-			}
-			return 0;
-		}
-
-		/**Called when this upgrade is applied to an item*/
-		public void onAppliedToItem(ItemStack itemStack){
-
-		}
-
-		/**Called when this upgrade is removed from an item*/
-		public void onRemovedFromItem(ItemStack itemStack){
-
-		}
-
-	}
-=======
     /**
      * @return a list of upgrades for this item.
      */
@@ -214,6 +33,8 @@ public interface IUpgradableItem {
     public int getMaxTier(ItemStack itemstack);
 
     public int getMaxUpgradePoints(int upgradeIndex);
+
+	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack);
 
     public int getBaseUpgradePoints(int upgradeIndex);
 
@@ -376,7 +197,7 @@ public interface IUpgradableItem {
             int totalPoints = applied[0] + (applied[1] * 2) + (applied[2] * 4) + (applied[3] * 8);
             if (itemStack != null && itemStack.getItem() instanceof IUpgradableItem) {
                 int points = ((IUpgradableItem) itemStack.getItem()).getBaseUpgradePoints(index) + (totalPoints / pointConversion);
-                return Math.min(points, ((IUpgradableItem) itemStack.getItem()).getMaxUpgradePoints(index));
+                return Math.min(points, ((IUpgradableItem) itemStack.getItem()).getMaxUpgradePoints(index, itemStack));
             }
             return 0;
         }
@@ -396,5 +217,4 @@ public interface IUpgradableItem {
         }
 
     }
->>>>>>> master
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/utills/IUpgradableItem.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/utills/IUpgradableItem.java
@@ -34,7 +34,7 @@ public interface IUpgradableItem {
 
     public int getMaxUpgradePoints(int upgradeIndex);
 
-	public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack);
+    public int getMaxUpgradePoints(int upgradeIndex, ItemStack stack);
 
     public int getBaseUpgradePoints(int upgradeIndex);
 


### PR DESCRIPTION
Hello.
Purpose of these changes is simple. Draconic Evolution is very cool mod, but it's very hard to configure it for modpack purposes, because many values are hardcoded.
I just added configuration file to change these values, to rebalance this mod.

Resume:
- Energy capacity and energy transfer of armor, tools and weapons are configurable.
- Amounts of upgrades for armor, tools and weapons are configurable.
- Energy storage of each tier of (Multiblock) Energy Core are configurable.
- Now it's possible to change main block of Energy Core structure (It is Block of Redstone by default. But for many modpacks it is very cheap resource for end-game energy storage. These changes allow to redefine it)
- Simplified code of Mob Grinder. Removed additional skull drop for Wither Sleletons (Even without it, Wither Skeletons drop skull pretty often with Mob Grinder. And I removed additional skull drop also because on some modpacks obtaining one from Skeletons is disabled). Added config options to enable looting enchantment for Mob Grinder, change size of energy buffer of this machine and change amount of energy required per kill.
- Now all values of Energy Infuser are configurable.
And finally, updated dependencies of mod.