### PR TITLE
Fixed a loading order issue.

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/DraconicEvolution.java
+++ b/src/main/java/com/brandon3055/draconicevolution/DraconicEvolution.java
@@ -26,7 +26,7 @@ public class DraconicEvolution {
     public static final String MOD_PREFIX = MODID.toLowerCase() + ":";
     public static final String PROXY_CLIENT = "com.brandon3055.draconicevolution.client.ClientProxy";
     public static final String PROXY_SERVER = "com.brandon3055.draconicevolution.CommonProxy";
-    public static final String DEPENDENCIES = "after:NotEnoughItems;before:ThermalExpansion;after:ThermalFoundation;required-after:brandonscore@[" + BrandonsCore.VERSION + ",);";
+    public static final String DEPENDENCIES = "after:immersiveengineering;after:NotEnoughItems;before:ThermalExpansion;after:ThermalFoundation;required-after:brandonscore@[" + BrandonsCore.VERSION + ",);";
     public static final String GUI_FACTORY = "";//TODO com.brandon3055.draconicevolution.client.gui.DEGUIFactory";
     public static final String networkChannelName = "DEvolutionNC";
     //region Misc Fields


### PR DESCRIPTION
So for some reason, when your JEI plugin loads after Immersive Engineering's JEI plugin, your recipes fail to add, I have no idea why this happens, all I know is that the issue is not Crafttweaker's fault, Crafttweaker simply exposed the bug somehow, our IJEIPlugin does nothing except set internal code for our usage and the issue is only brought to light in the 3.0.17+ versions of CrT since we added a "after:JEI;" to our dependency list, running a lower version of CrT without the dependency but with the same IJEIPlugin does not affect how your recipes are shown.

I am willing to bet that any mod that naturally starts before DE (as in just from file name), but has an IJEIPlugin and has "after:JEI;" would reproduce this issue, however this is the fix I found to make it work in SF3.

This also fixes https://github.com/BluSunrize/ImmersiveEngineering/issues/1890
