### PR TITLE
Cancel scroll event instead of changing current item

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/client/keybinding/KeyInputHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/keybinding/KeyInputHandler.java
@@ -11,11 +11,11 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraftforge.client.event.MouseEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.lwjgl.input.Mouse;
 
 /**
  * Created by Brandon on 14/08/2014.
@@ -67,7 +67,7 @@ public class KeyInputHandler {
 
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
-    public void onMouseInput(InputEvent.MouseInputEvent event) {
+    public void onMouseInput(MouseEvent event) {
         EntityPlayer player = Minecraft.getMinecraft().player;
         if (player == null) {
             return;
@@ -91,29 +91,15 @@ public class KeyInputHandler {
 //			}
         }
 
-        int change = Mouse.getEventDWheel();
+        int change = event.getDwheel();
         if (change == 0 || !player.isSneaking()) return;
 
-        if (change > 0) {
-            ItemStack item = player.inventory.getStackInSlot(previouseSlot(1, player.inventory.currentItem));
-            if (item != null && item.getItem() == DEFeatures.dislocatorAdvanced) {
-                player.inventory.currentItem = previouseSlot(1, player.inventory.currentItem);
-                DraconicEvolution.network.sendToServer(new PacketDislocator(PacketDislocator.SCROLL, -1, false));
-            }
+        ItemStack item = player.inventory.getStackInSlot(player.inventory.currentItem);
+        if (item.getItem() == DEFeatures.dislocatorAdvanced) {
+            if (event.isCancelable())
+                event.setCanceled(true);
+            DraconicEvolution.network.sendToServer(new PacketDislocator(PacketDislocator.SCROLL, change < 0 ? -1 : 1,
+                    false));
         }
-        else if (change < 0) {
-            ItemStack item = player.inventory.getStackInSlot(previouseSlot(-1, player.inventory.currentItem));
-            if (item != null && item.getItem() == DEFeatures.dislocatorAdvanced) {
-                player.inventory.currentItem = previouseSlot(-1, player.inventory.currentItem);
-                DraconicEvolution.network.sendToServer(new PacketDislocator(PacketDislocator.SCROLL, 1, false));
-            }
-        }
-    }
-
-    private int previouseSlot(int i, int c) {
-        if (c > 0 && c < 8) return c + i;
-        if (c == 0 && i < 0) return 8;
-        if (c == 8 && i > 0) return 0;
-        return c + i;
     }
 }


### PR DESCRIPTION
The advanced dislocator, scroll event handler subscribes to the mouse input event that is fired after the vanilla hotbar handler has changed the current item. Subscribing to MouseEvent and canceling the event achieves the same effect. The event is canceled before the vanilla hotbar handler gets it and it stops propagation to other (mod) handlers.