### PR TITLE
Fixed enchantments in configuration GUI

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/api/itemconfig/ItemConfigFieldRegistry.java
+++ b/src/main/java/com/brandon3055/draconicevolution/api/itemconfig/ItemConfigFieldRegistry.java
@@ -4,7 +4,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -12,7 +12,7 @@ import java.util.Map;
  * A simple map wrapper for handling IItemConfigField's
  */
 public class ItemConfigFieldRegistry {
-    private Map<String, IItemConfigField> fields = new HashMap<>();
+    private Map<String, IItemConfigField> fields = new LinkedHashMap<>();
 
     /**
      * Adds a field to the registry and reads its current value from the given item stack.

--- a/src/main/java/com/brandon3055/draconicevolution/api/itemconfig/ItemConfigFieldRegistry.java
+++ b/src/main/java/com/brandon3055/draconicevolution/api/itemconfig/ItemConfigFieldRegistry.java
@@ -12,17 +12,14 @@ import java.util.Map;
  * A simple map wrapper for handling IItemConfigField's
  */
 public class ItemConfigFieldRegistry {
-    protected Map<Integer, IItemConfigField> fieldRegistry = new HashMap<Integer, IItemConfigField>();
-    protected Map<String, Integer> nameToIndexMap = new HashMap<String, Integer>();
-    private int index = 0;
+    private Map<String, IItemConfigField> fields = new HashMap<>();
 
     /**
      * Adds a field to the registry and reads its current value from the given item stack.
      * Will also write the default value to the stack if the stack dose not contain a tag for this field.
      */
     public ItemConfigFieldRegistry register(ItemStack stack, IItemConfigField field) {
-        fieldRegistry.put(index, field);
-        nameToIndexMap.put(field.getName(), index);
+        fields.put(field.getName(), field);
 
         NBTTagCompound fieldStorage = ToolConfigHelper.getFieldStorage(stack);
         if (!fieldStorage.hasKey(field.getName())) {
@@ -31,45 +28,22 @@ public class ItemConfigFieldRegistry {
         else {
             field.readFromNBT(fieldStorage);
         }
-
-        index++;
         return this;
     }
 
-    public IItemConfigField getField(int index) {
-        return fieldRegistry.get(index);
-    }
-
     public IItemConfigField getField(String name) {
-        for (IItemConfigField field : fieldRegistry.values()) {
-            if (field.getName().equals(name)) {
-                return field;
-            }
-        }
-        return null;
-    }
-
-    public String getNameFromIndex(int index) {
-        IItemConfigField field = getField(index);
-        return field == null ? "" : field.getName();
-    }
-
-    public int getIndexFromName(String name) {
-        Integer index = nameToIndexMap.get(name);
-        return index == null ? -1 : index;
+        return fields.get(name);
     }
 
     public Collection<IItemConfigField> getFields() {
-        return fieldRegistry.values();
+        return fields.values();
     }
 
     public void clear() {
-        index = 0;
-        fieldRegistry.clear();
-        nameToIndexMap.clear();
+        fields.clear();
     }
 
     public int size() {
-        return fieldRegistry.size();
+        return fields.size();
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/toolconfig/GuiConfigureTool.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/toolconfig/GuiConfigureTool.java
@@ -572,8 +572,7 @@ public class GuiConfigureTool extends GuiScreen implements GuiPageButtonList.Gui
                     case SLIDER:
                         if (isDragging) {
                             double pos = (mouseX - 3 - (x + 4D)) / (width - 14D);
-                            int fieldIndex = gui.fieldRegistry.getIndexFromName(activeButton.field.getName());
-                            DraconicEvolution.network.sendToServer(new PacketConfigureTool(slot, fieldIndex, EnumButton.SLIDER.index, (int) (pos * 10000D)));
+                            DraconicEvolution.network.sendToServer(new PacketConfigureTool(slot, activeButton.field.getName(), EnumButton.SLIDER.index, (int) (pos * 10000D)));
                             mc.getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 0.9F));
                         }
                         break;
@@ -601,9 +600,7 @@ public class GuiConfigureTool extends GuiScreen implements GuiPageButtonList.Gui
                 return;
             }
 
-            int fieldIndex = gui.fieldRegistry.getIndexFromName(activeButton.field.getName());
-
-            DraconicEvolution.network.sendToServer(new PacketConfigureTool(slot, fieldIndex, button.enumButton.index, button.selectionIndex));
+            DraconicEvolution.network.sendToServer(new PacketConfigureTool(slot, activeButton.field.getName(), button.enumButton.index, button.selectionIndex));
 
             mc.getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1.0F));
         }

--- a/src/main/java/com/brandon3055/draconicevolution/network/PacketConfigureTool.java
+++ b/src/main/java/com/brandon3055/draconicevolution/network/PacketConfigureTool.java
@@ -9,6 +9,7 @@ import com.brandon3055.draconicevolution.api.itemconfig.ToolConfigHelper;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 
@@ -18,17 +19,17 @@ import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 public class PacketConfigureTool implements IMessage {
 
     public PlayerSlot slot;
-    public int fieldIndex;
+    public String field;
     public int button;
     public int data;
 
     public PacketConfigureTool() {
     }
 
-    public PacketConfigureTool(PlayerSlot slot, int fieldIndex, int button, int data) {
+    public PacketConfigureTool(PlayerSlot slot, String field, int button, int data) {
 
         this.slot = slot;
-        this.fieldIndex = fieldIndex;
+        this.field = field;
         this.button = button;
         this.data = data;
     }
@@ -36,7 +37,7 @@ public class PacketConfigureTool implements IMessage {
     @Override
     public void toBytes(ByteBuf buf) {
         slot.toBuff(buf);
-        buf.writeByte(fieldIndex);
+        ByteBufUtils.writeUTF8String(buf, field);
         buf.writeByte(button);
         buf.writeShort(data);
     }
@@ -44,7 +45,7 @@ public class PacketConfigureTool implements IMessage {
     @Override
     public void fromBytes(ByteBuf buf) {
         slot = PlayerSlot.fromBuff(buf);
-        fieldIndex = buf.readByte();
+        field = ByteBufUtils.readUTF8String(buf);
         button = buf.readByte();
         data = buf.readShort();
     }
@@ -60,7 +61,7 @@ public class PacketConfigureTool implements IMessage {
             }
 
             IConfigurableItem item = (IConfigurableItem) stack.getItem();
-            IItemConfigField field = item.getFields(stack, new ItemConfigFieldRegistry()).getField(message.fieldIndex);
+            IItemConfigField field = item.getFields(stack, new ItemConfigFieldRegistry()).getField(message.field);
 
             if (field != null) {
                 field.handleButton(IItemConfigField.EnumButton.getButton(message.button), message.data, player, message.slot);


### PR DESCRIPTION
The issue still persisted when playing on a server. Turned out that the client and server were registering enchantment fields in different orders (and hence giving them different indices).

Example:
```
Client opens GUI:
[21:56:45] [main/INFO] [draconicevolution]: register(index=0,attackAOE)
[21:56:45] [main/INFO] [draconicevolution]: register(index=1,digSpeed)
...
[21:56:45] [main/INFO] [draconicevolution]: register(index=9,minecraft:efficiency)
[21:56:45] [main/INFO] [draconicevolution]: register(index=10,minecraft:silk_touch)
[21:56:45] [main/INFO] [draconicevolution]: register(index=11,minecraft:fortune)
[21:56:45] [main/INFO] [draconicevolution]: register(index=12,minecraft:sharpness)

Client toggles an enchantment (sends index 12 for sharpness):
[21:57:01] [Server thread/INFO] [draconicevolution]: register(index=0,attackAOE)
[21:57:01] [Server thread/INFO] [draconicevolution]: register(index=1,digSpeed)
...
[21:57:01] [Server thread/INFO] [draconicevolution]: register(index=9,minecraft:sharpness)
[21:57:01] [Server thread/INFO] [draconicevolution]: register(index=10,minecraft:efficiency)
[21:57:01] [Server thread/INFO] [draconicevolution]: register(index=11,minecraft:silk_touch)
[21:57:01] [Server thread/INFO] [draconicevolution]: register(index=12,minecraft:fortune)
[21:57:01] [Server thread/INFO] [draconicevolution]: PacketConfigureTool(index=12,name=minecraft:fortune)
```

Primary changes in this pull request are removing the indices and simply using the field names. This removed the syncing issue:

```
Client opens GUI:
[22:13:34] [main/INFO] [draconicevolution]: register(name=attackAOE)
[22:13:34] [main/INFO] [draconicevolution]: register(name=digSpeed)
...
[22:13:34] [main/INFO] [draconicevolution]: register(name=minecraft:efficiency)
[22:13:34] [main/INFO] [draconicevolution]: register(name=minecraft:silk_touch)
[22:13:34] [main/INFO] [draconicevolution]: register(name=minecraft:fortune)
[22:13:34] [main/INFO] [draconicevolution]: register(name=minecraft:sharpness)

Client toggles an enchantment (sends "minecraft:fortune"):
[22:13:59] [Server thread/INFO] [draconicevolution]: register(name=attackAOE)
[22:13:59] [Server thread/INFO] [draconicevolution]: register(name=digSpeed)
...
[22:13:59] [Server thread/INFO] [draconicevolution]: register(name=minecraft:sharpness)
[22:13:59] [Server thread/INFO] [draconicevolution]: register(name=minecraft:efficiency)
[22:13:59] [Server thread/INFO] [draconicevolution]: register(name=minecraft:silk_touch)
[22:13:59] [Server thread/INFO] [draconicevolution]: register(name=minecraft:fortune)
[22:13:59] [Server thread/INFO] [draconicevolution]: PacketConfigureTool(name=minecraft:fortune)
```

Fixes (as far as my testing goes) #903 