### PR TITLE
Fix Magnet with conveyors

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/items/tools/Magnet.java
@@ -88,7 +88,7 @@ public class Magnet extends ItemBCore implements IBauble {
                     continue;
                 }
 
-                NBTTagCompound itemTag = item.getTagCompound();
+                NBTTagCompound itemTag = itemEntity.getTagCompound();
                 if (itemTag != null && itemTag.hasKey("PreventRemoteMovement")) {
                     continue;
                 }


### PR DESCRIPTION
The PreventRemoteMovement tag is set on the ItemEntity, not the ItemStack.