### PR TITLE
Fix to Energy Core losing energy on unload.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 mc_version=1.12.2
 mod_version=2.3.18
-forge_version=14.23.1.2566
+forge_version=14.23.5.2811
 mappings=snapshot_20171003
 bcore_version=2.4.9.+
 pi_version=1.0.1.+

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyStorageCore.java
@@ -362,6 +362,7 @@ public class TileEnergyStorageCore extends TileBCBase implements ITickable, IExt
 
         if (!simulate) {
             energy.value += energyReceived;
+            markDirty();
         }
         return (int) energyReceived;
     }
@@ -374,6 +375,7 @@ public class TileEnergyStorageCore extends TileBCBase implements ITickable, IExt
 
         if (!simulate) {
             energy.value -= energyExtracted;
+            markDirty();
         }
         return (int) energyExtracted;
     }


### PR DESCRIPTION
Fix for when Energy core is the only block in a chunk. Energy value not being stored when game unloading. 
Also updated Forge version.