### PR TITLE
Update to new Forge build system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 minecraft {
-    version = config.mc_version + "-" + config.forge_version
+    version = config.mc_version + "-latest"
     runDir = "run"
     mappings = "${config.mappings}"
     replace '${mod_version}', project.config.mod_version

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,5 @@
 mc_version=1.12.2
 mod_version=2.3.20
-forge_version=14.23.5.2811
 mappings=snapshot_20171003
 bcore_version=2.4.9.+
 pi_version=1.0.1.+

--- a/src/main/java/com/brandon3055/draconicevolution/lib/VersionHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/lib/VersionHandler.java
@@ -10,5 +10,3 @@ public class VersionHandler {
 
     public static final String FULL_VERSION = VERSION + (SNAPSHOT > 0 ? "-snapshot_" + SNAPSHOT : "");
 }
-
-


### PR DESCRIPTION
Updated to comply with Forge's new method for acquiring versions.  Also, removed extra returns in the file "VersionHandler.java" that prevented the gradle script from being able to run "sourceJar", though it's practically useless anyways.