### PR TITLE
Added config option to disable energy consumption of the Entity Detector

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/DEConfig.java
+++ b/src/main/java/com/brandon3055/draconicevolution/DEConfig.java
@@ -198,8 +198,11 @@ public class DEConfig implements IModConfigHelper {
     @ModConfigProperty(category = "Tweaks", name = "draconicFluxCapBaseCap", comment = "This allows you to adjust the base capacity of the Draconic Flux Capacitor.")
     public static int draconicFluxCapBaseCap = 256000000;
     
-    @ModConfigProperty(category = "Tweaks", name = "disableEntityDetectorEnergyConsumption", comment = "Disables the energy consumption of the Entity Detector and the Advanced Entity Detector.")
-    public static boolean disableEntityDetectorEnergyConsumption = false;
+    @ModConfigProperty(category = "Tweaks", name = "entityDetectorEnergyMultiplier", comment = "The multiplier of the energy consumption formula for the Entity Detector and Advanced Entity Detector. Formula: multiplier * range ^ exponent")
+    public static double entityDetectorEnergyMultiplier = 125;
+    
+    @ModConfigProperty(category = "Tweaks", name = "entityDetectorEnergyExponent", comment = "The exponent of the energy consumption formula for the Entity Detector and Advanced Entity Detector. Formula: multiplier * range ^ exponent")
+    public static double entityDetectorEnergyExponent = 1.5;
 
     //Category Client
 

--- a/src/main/java/com/brandon3055/draconicevolution/DEConfig.java
+++ b/src/main/java/com/brandon3055/draconicevolution/DEConfig.java
@@ -197,6 +197,9 @@ public class DEConfig implements IModConfigHelper {
 
     @ModConfigProperty(category = "Tweaks", name = "draconicFluxCapBaseCap", comment = "This allows you to adjust the base capacity of the Draconic Flux Capacitor.")
     public static int draconicFluxCapBaseCap = 256000000;
+    
+    @ModConfigProperty(category = "Tweaks", name = "disableEntityDetectorEnergyConsumption", comment = "Disables the energy consumption of the Entity Detector and the Advanced Entity Detector.")
+    public static boolean disableEntityDetectorEnergyConsumption = false;
 
     //Category Client
 

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEntityDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEntityDetector.java
@@ -13,6 +13,7 @@ import com.brandon3055.brandonscore.lib.datamanager.ManagedBool;
 import com.brandon3055.brandonscore.lib.datamanager.ManagedByte;
 import com.brandon3055.brandonscore.lib.datamanager.ManagedShort;
 import com.brandon3055.brandonscore.utils.Utils;
+import com.brandon3055.draconicevolution.DEConfig;
 import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.GuiHandler;
 import com.brandon3055.draconicevolution.blocks.machines.EntityDetector;
@@ -374,6 +375,9 @@ public class TileEntityDetector extends TileEnergyBase implements IActivatableTi
     }
 
     public int getPulseCost() {
+        if (DEConfig.disableEntityDetectorEnergyConsumption) {
+            return 0;
+        }
         return (int) (125 * Math.pow(RANGE.value, 1.5));
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEntityDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEntityDetector.java
@@ -375,10 +375,9 @@ public class TileEntityDetector extends TileEnergyBase implements IActivatableTi
     }
 
     public int getPulseCost() {
-        if (DEConfig.disableEntityDetectorEnergyConsumption) {
-            return 0;
-        }
-        return (int) (125 * Math.pow(RANGE.value, 1.5));
+        double multiplier = DEConfig.entityDetectorEnergyMultiplier;
+        double exponent = DEConfig.entityDetectorEnergyExponent;
+        return (int) (multiplier * Math.pow(RANGE.value, exponent));
     }
 
     @Override

--- a/src/main/resources/assets/draconicevolution/lang/en_US.lang
+++ b/src/main/resources/assets/draconicevolution/lang/en_US.lang
@@ -832,7 +832,7 @@ gui.entityDetector.rsMin.info=The minimum number of detected entities required t
 gui.entityDetector.rsMax=RS Max Threshold
 gui.entityDetector.rsMax.info=The minimum number of detected entities required to produce a redstone signal of 15.
 gui.entityDetector.energyCost=Energy Per Pulse
-gui.entityDetector.energyCost.info=This is the amount of energy required for each scanning pulse. The energy requires is 125 * range^1.5 This means the energy cost increases exponentially as you increase the range.
+gui.entityDetector.energyCost.info=This is the amount of energy required for each scanning pulse. The default energy required is 125 * range^1.5 This means the energy cost increases exponentially as you increase the range.
 gui.entityDetector.filter=Open Entity Filter Configurator
 
 //---- Energy Net ----//


### PR DESCRIPTION
Config option disables energy Consumption for both the Entity Detector, as well as the Advanced Energy Detector.

Implements https://github.com/brandon3055/Draconic-Evolution/issues/1371