### PR TITLE
Moved Hardcoded Peripherals to Optional Capability

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/CommonProxy.java
+++ b/src/main/java/com/brandon3055/draconicevolution/CommonProxy.java
@@ -10,12 +10,14 @@ import com.brandon3055.draconicevolution.client.render.tile.fxhandlers.ITileFXHa
 import com.brandon3055.draconicevolution.handlers.DEEventHandler;
 import com.brandon3055.draconicevolution.init.DETags;
 import com.brandon3055.draconicevolution.init.ModCapabilities;
+import com.brandon3055.draconicevolution.integration.computers.ComputerCraftCompatEventHandler;
 import com.brandon3055.draconicevolution.integration.equipment.EquipmentManager;
 import com.brandon3055.draconicevolution.items.tools.Dislocator;
 import com.brandon3055.draconicevolution.lib.ISidedTileHandler;
 import com.brandon3055.draconicevolution.network.DraconicNetwork;
 import net.minecraft.client.audio.ISound;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.OptionalMod;
 import net.minecraftforge.fml.event.lifecycle.*;
 
 public class CommonProxy {
@@ -30,6 +32,7 @@ public class CommonProxy {
         MinecraftForge.EVENT_BUS.addListener(Dislocator::onAnvilUpdate); //TODO move this to an event handler before covers yells at me
 
         MinecraftForge.EVENT_BUS.register(new DEEventHandler());
+		OptionalMod.of("computercraft").ifPresent(e -> MinecraftForge.EVENT_BUS.register(new ComputerCraftCompatEventHandler()));
 
         EquipmentManager.initialize();
     }

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/reactor/tileentity/TileReactorComponent.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/reactor/tileentity/TileReactorComponent.java
@@ -1,7 +1,6 @@
 package com.brandon3055.draconicevolution.blocks.reactor.tileentity;
 
 import codechicken.lib.data.MCDataInput;
-import dan200.computercraft.shared.Capabilities;
 
 import com.brandon3055.brandonscore.blocks.TileBCore;
 import com.brandon3055.brandonscore.lib.Vec3I;
@@ -50,7 +49,6 @@ public abstract class TileReactorComponent extends TileBCore implements ITickabl
 
     public TileReactorComponent(TileEntityType<?> tileEntityTypeIn) {
         super(tileEntityTypeIn);
-        capManager.set(Capabilities.CAPABILITY_PERIPHERAL, new PeripheralReactorComponent(this));
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyPylon.java
@@ -23,8 +23,6 @@ import com.brandon3055.draconicevolution.client.DEParticles;
 import com.brandon3055.draconicevolution.init.DEContent;
 import com.brandon3055.draconicevolution.integration.computers.PeripheralEnergyPylon;
 
-import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.shared.Capabilities;
 import net.minecraft.block.Blocks;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -123,7 +121,6 @@ public class TileEnergyPylon extends TileBCore implements ITickableTileEntity, I
     public TileEnergyPylon() {
         super(DEContent.tile_energy_pylon);
         capManager.set(CapabilityOP.OP, opAdapter);
-        capManager.set(Capabilities.CAPABILITY_PERIPHERAL, new PeripheralEnergyPylon(this));
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/flowgate/TileFlowGate.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/flowgate/TileFlowGate.java
@@ -1,7 +1,6 @@
 package com.brandon3055.draconicevolution.blocks.tileentity.flowgate;
 
 import codechicken.lib.data.MCDataInput;
-import dan200.computercraft.shared.Capabilities;
 
 import com.brandon3055.brandonscore.blocks.TileBCore;
 import com.brandon3055.brandonscore.lib.IInteractTile;
@@ -42,7 +41,6 @@ public abstract class TileFlowGate extends TileBCore implements ITickableTileEnt
 
     public TileFlowGate(TileEntityType<?> tileEntityTypeIn) {
         super(tileEntityTypeIn);
-        capManager.set(Capabilities.CAPABILITY_PERIPHERAL, new PeripheralFlowGate(this));
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/flowgate/TileFluidGate.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/flowgate/TileFluidGate.java
@@ -1,7 +1,6 @@
 package com.brandon3055.draconicevolution.blocks.tileentity.flowgate;
 
 import codechicken.lib.util.SneakyUtils;
-import dan200.computercraft.shared.Capabilities;
 
 import com.brandon3055.brandonscore.inventory.ContainerBCTile;
 import com.brandon3055.draconicevolution.init.DEContent;
@@ -35,7 +34,6 @@ public class TileFluidGate extends TileFlowGate implements IFluidHandler {
 
     public TileFluidGate() {
         super(DEContent.tile_fluid_gate);
-        capManager.set(Capabilities.CAPABILITY_PERIPHERAL, new PeripheralFluidGate(this));
     }
 
     //region Gate

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/flowgate/TileFluxGate.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/flowgate/TileFluxGate.java
@@ -2,7 +2,6 @@ package com.brandon3055.draconicevolution.blocks.tileentity.flowgate;
 
 import codechicken.lib.data.MCDataInput;
 import codechicken.lib.util.SneakyUtils;
-import dan200.computercraft.shared.Capabilities;
 
 import com.brandon3055.brandonscore.api.power.IOPStorage;
 import com.brandon3055.brandonscore.blocks.TileBCore;
@@ -40,7 +39,6 @@ public class TileFluxGate extends TileFlowGate {
 
     public TileFluxGate() {
         super(DEContent.tile_flux_gate);
-        capManager.set(Capabilities.CAPABILITY_PERIPHERAL, new PeripheralFluxGate(this));
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/ComputerCraftCompatEventHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/ComputerCraftCompatEventHandler.java
@@ -1,0 +1,54 @@
+package com.brandon3055.draconicevolution.integration.computers;
+
+import com.brandon3055.brandonscore.blocks.TileBCore;
+import com.brandon3055.draconicevolution.DraconicEvolution;
+import com.brandon3055.draconicevolution.blocks.reactor.tileentity.TileReactorComponent;
+import com.brandon3055.draconicevolution.blocks.tileentity.TileEnergyPylon;
+import com.brandon3055.draconicevolution.blocks.tileentity.flowgate.TileFlowGate;
+import com.brandon3055.draconicevolution.blocks.tileentity.flowgate.TileFluidGate;
+import com.brandon3055.draconicevolution.blocks.tileentity.flowgate.TileFluxGate;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class ComputerCraftCompatEventHandler {
+    
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public void onAttachCapabilities(AttachCapabilitiesEvent<TileEntity> event) {
+    	if (event.getObject() instanceof TileBCore) {
+    		TileBCore tile = (TileBCore)event.getObject();
+	    	if (tile instanceof TileReactorComponent) {
+	    		PeripheralReactorComponent peripheral = new PeripheralReactorComponent((TileReactorComponent)tile);
+	            event.addCapability(new ResourceLocation(DraconicEvolution.MODID, peripheral.getType()), peripheral);
+	            event.addListener(peripheral::invalidate);
+	        }
+	    	else if (tile instanceof TileEnergyPylon) {
+	    		TileEnergyPylon tileEntity = (TileEnergyPylon)tile;
+	    		PeripheralEnergyPylon peripheral = new PeripheralEnergyPylon((TileEnergyPylon)tile);
+	            event.addCapability(new ResourceLocation(DraconicEvolution.MODID, peripheral.getType()), peripheral);
+	            event.addListener(peripheral::invalidate);
+	        }
+	    	else if (tile instanceof TileFlowGate) {
+	    		TileFlowGate tileEntity = (TileFlowGate)tile;
+	    		PeripheralFlowGate peripheral = new PeripheralFlowGate((TileFlowGate)tile);
+	            event.addCapability(new ResourceLocation(DraconicEvolution.MODID, peripheral.getType()), peripheral);
+	            event.addListener(peripheral::invalidate);
+	        }
+	    	else if (tile instanceof TileFluidGate) {
+	    		TileFluidGate tileEntity = (TileFluidGate)tile;
+	    		PeripheralFluidGate peripheral = new PeripheralFluidGate((TileFluidGate)tile);
+	            event.addCapability(new ResourceLocation(DraconicEvolution.MODID, peripheral.getType()), peripheral);
+	            event.addListener(peripheral::invalidate);
+	        }
+	    	else if (tile instanceof TileFluxGate) {
+	    		TileFluxGate tileEntity = (TileFluxGate)tile;
+	    		PeripheralFluxGate peripheral = new PeripheralFluxGate((TileFluxGate)tile);
+	            event.addCapability(new ResourceLocation(DraconicEvolution.MODID, peripheral.getType()), peripheral);
+	            event.addListener(peripheral::invalidate);
+	        }
+	    }
+    }
+}

--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralEnergyPylon.java
@@ -1,13 +1,22 @@
 package com.brandon3055.draconicevolution.integration.computers;
 
+import static dan200.computercraft.shared.Capabilities.CAPABILITY_PERIPHERAL;
+
 import com.brandon3055.draconicevolution.blocks.tileentity.TileEnergyPylon;
 
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.shared.util.CapabilityUtil;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
 
-public class PeripheralEnergyPylon implements IPeripheral {
+public class PeripheralEnergyPylon implements IPeripheral, ICapabilityProvider {
 	
 	TileEnergyPylon tile;
+	private LazyOptional<IPeripheral> self;
+	
 	public PeripheralEnergyPylon(TileEnergyPylon tile) {
         this.tile = tile;
     }
@@ -39,4 +48,17 @@ public class PeripheralEnergyPylon implements IPeripheral {
         }
         return tile.getCore().transferRate.get();
 	}
+	
+	@Override
+	public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
+		if (cap == CAPABILITY_PERIPHERAL) {
+            if (self == null) self = LazyOptional.of(() -> this);
+            return self.cast();
+        }
+        return LazyOptional.empty();
+	}
+	
+	public void invalidate() {
+        self = CapabilityUtil.invalidate(self);
+    }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralFlowGate.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralFlowGate.java
@@ -1,13 +1,22 @@
 package com.brandon3055.draconicevolution.integration.computers;
 
+import static dan200.computercraft.shared.Capabilities.CAPABILITY_PERIPHERAL;
+
 import com.brandon3055.draconicevolution.blocks.tileentity.flowgate.TileFlowGate;
 
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.shared.util.CapabilityUtil;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
 
-public class PeripheralFlowGate implements IPeripheral {
+public class PeripheralFlowGate implements IPeripheral, ICapabilityProvider {
 	
 	TileFlowGate tile;
+	private LazyOptional<IPeripheral> self;
+	
 	public PeripheralFlowGate(TileFlowGate tile) {
         this.tile = tile;
     }
@@ -61,4 +70,17 @@ public class PeripheralFlowGate implements IPeripheral {
 	public final long getSignalLowFlow() {
 		return tile.minFlow.get();
 	}
+
+	@Override
+	public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
+		if (cap == CAPABILITY_PERIPHERAL) {
+            if (self == null) self = LazyOptional.of(() -> this);
+            return self.cast();
+        }
+        return LazyOptional.empty();
+	}
+	
+	public void invalidate() {
+        self = CapabilityUtil.invalidate(self);
+    }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralReactorComponent.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralReactorComponent.java
@@ -1,5 +1,7 @@
 package com.brandon3055.draconicevolution.integration.computers;
 
+import static dan200.computercraft.shared.Capabilities.CAPABILITY_PERIPHERAL;
+
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -10,11 +12,18 @@ import com.brandon3055.draconicevolution.blocks.reactor.tileentity.TileReactorCo
 
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.shared.util.CapabilityUtil;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
 
-public class PeripheralReactorComponent implements IPeripheral {
+public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvider {
 	
 	TileReactorComponent tile;
 	TileReactorCore reactor;
+	private LazyOptional<IPeripheral> self;
+	
 	public PeripheralReactorComponent(TileReactorComponent tile) {
         this.tile = tile;
     }
@@ -89,4 +98,17 @@ public class PeripheralReactorComponent implements IPeripheral {
 	public final void setFailSafe(boolean state) {
 		reactor.failSafeMode.set(state);
 	}
+	
+	@Override
+	public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
+		if (cap == CAPABILITY_PERIPHERAL) {
+            if (self == null) self = LazyOptional.of(() -> this);
+            return self.cast();
+        }
+        return LazyOptional.empty();
+	}
+	
+	public void invalidate() {
+        self = CapabilityUtil.invalidate(self);
+    }
 }


### PR DESCRIPTION
This makes it to where ComputerCraft is no longer a required dependency.  This was a mistake on my part in how it was implemented.