### PR TITLE
Remove state parameter from CC `getTransferPerTick` method

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralEnergyPylon.java
@@ -42,7 +42,7 @@ public class PeripheralEnergyPylon implements IPeripheral, ICapabilityProvider {
 	}
 	
 	@LuaFunction
-	public final long getTransferPerTick(boolean state) {
+	public final long getTransferPerTick() {
 		if (!tile.hasCoreLock.get() || tile.getCore() == null) {
             return 0;
         }


### PR DESCRIPTION
The `getTransferPerTick` function in ComputerCraft currently expects a boolean argument called `state`; however, this argument does nothing except break code that tries to call it with no arguments. This PR removes the useless argument, allowing code that uses no arguments to work as expected, and making it no longer necessary to pass a dummy argument in.