### PR TITLE
Serialized "flow" in EnergyLinkEntity

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/api/modules/entities/EnergyLinkEntity.java
+++ b/src/main/java/com/brandon3055/draconicevolution/api/modules/entities/EnergyLinkEntity.java
@@ -42,12 +42,12 @@ public class EnergyLinkEntity extends ModuleEntity<EnergyLinkData> {
     private Optional<UUID> linkId = Optional.empty();
     //This shouldn't be saved to item, or maybe just clear on insert?
     private long linkCharge = 0;
+    private double flow = 0;
 
     //Component data can probably still be set from entity constructor.
     private BooleanProperty enabled = new BooleanProperty("energy_link_mod.enabled", true).setFormatter(ConfigProperty.BooleanFormatter.ENABLED_DISABLED);
 
     //Not Serialised
-    private double flow = 0;
 //    private boolean coreEnergyLow = false;
 
     public static final Codec<EnergyLinkEntity> CODEC = RecordCodecBuilder.create(builder -> builder.group(
@@ -57,6 +57,7 @@ public class EnergyLinkEntity extends ModuleEntity<EnergyLinkData> {
             GlobalPos.CODEC.optionalFieldOf("linked_pos").forGetter(e -> e.linkedPos),
             UUIDUtil.CODEC.optionalFieldOf("link_id").forGetter(e -> e.linkId),
             Codec.LONG.fieldOf("link_charge").forGetter(e -> e.linkCharge),
+            Codec.DOUBLE.fieldOf("flow").forGetter(e -> e.flow),
             BooleanProperty.CODEC.fieldOf("enabled").forGetter(e -> e.enabled)
             ).apply(builder, EnergyLinkEntity::new));
 
@@ -67,6 +68,7 @@ public class EnergyLinkEntity extends ModuleEntity<EnergyLinkData> {
             ByteBufCodecs.optional(GlobalPos.STREAM_CODEC), energyLinkEntity -> energyLinkEntity.linkedPos,
             ByteBufCodecs.optional(UUIDUtil.STREAM_CODEC), energyLinkEntity -> energyLinkEntity.linkId,
             ByteBufCodecs.VAR_LONG, energyLinkEntity -> energyLinkEntity.linkCharge,
+            ByteBufCodecs.DOUBLE, energyLinkEntity -> energyLinkEntity.flow,
             BooleanProperty.STREAM_CODEC, energyLinkEntity -> energyLinkEntity.enabled,
             EnergyLinkEntity::new
     );
@@ -75,17 +77,18 @@ public class EnergyLinkEntity extends ModuleEntity<EnergyLinkData> {
         super(module);
     }
 
-    EnergyLinkEntity(Module<?> module, int gridX, int gridY, Optional<GlobalPos> linkedPos, Optional<UUID> linkId, long linkCharge, BooleanProperty enabled) {
+    EnergyLinkEntity(Module<?> module, int gridX, int gridY, Optional<GlobalPos> linkedPos, Optional<UUID> linkId, long linkCharge, double flow, BooleanProperty enabled) {
         super((Module<EnergyLinkData>) module, gridX, gridY);
         this.linkedPos = linkedPos;
         this.linkId = linkId;
         this.linkCharge = linkCharge;
+        this.flow = flow;
         this.enabled = enabled;
     }
 
     @Override
     public ModuleEntity<?> copy() {
-        return new EnergyLinkEntity(module, getGridX(), getGridY(), linkedPos, linkId, linkCharge, enabled.copy());
+        return new EnergyLinkEntity(module, getGridX(), getGridY(), linkedPos, linkId, linkCharge, flow, enabled.copy());
     }
 
     @Override


### PR DESCRIPTION
EnergyLinkEntity is recreated every tick, seemingly; this reinitializes the variable "flow" to 0 every tick, meaning that the minimum amount of OP is taken as maintainanceCost for all Energy Link Modules.  There's probably a better way to do this, but this fix does work.

Please let me know what additional changes need to be made.

WARNING: This seems to break existing worlds.