### PR TITLE
[1.21.1] Improve compatibility with enchantments, etc

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileGrinder.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileGrinder.java
@@ -208,8 +208,11 @@ public class TileGrinder extends TileBCore implements IRSSwitchable, MenuProvide
         }
 
         ItemStack weapon = itemHandler.getStackInSlot(1);
-        getFakePlayer().setItemInHand(InteractionHand.MAIN_HAND, weapon);
-
+        BlockPos pos = getBlockPos();
+        FakePlayer fakePlayer = getFakePlayer();
+        fakePlayer.setItemInHand(InteractionHand.MAIN_HAND, weapon);
+        fakePlayer.absMoveTo(pos.getX(), pos.getY(), pos.getZ(), 90, 90);
+        
         int eph = DEConfig.grinderEnergyPerHeart;
         float health = nextTarget.getHealth();
 
@@ -231,14 +234,14 @@ public class TileGrinder extends TileBCore implements IRSSwitchable, MenuProvide
 
         //Dont mess around. If we know the mob should die lets just make it die!
         float damage = willKill ? Float.MAX_VALUE / 5F : ((float) cost / (float) eph) * 1.1F;
-        DamageSource source = level.damageSources().playerAttack(getFakePlayer());
+        DamageSource source = level.damageSources().playerAttack(fakePlayer);
 
         //Attack the mob and enter cooldown mode for 5 ticks if successful. Else cooldown for 3 ticks.
         if (nextTarget.hurt(source, damage)) {
             if (!weapon.isEmpty()) {
                 ItemStack justInCase = weapon.copy();
                 justInCase.setDamageValue(justInCase.getMaxDamage() - 1);
-                weapon.hurtAndBreak(1, (ServerLevel) level, getFakePlayer(), item -> itemHandler.setStackInSlot(1, justInCase));
+                weapon.hurtAndBreak(1, (ServerLevel) level, fakePlayer, item -> itemHandler.setStackInSlot(1, justInCase));
             }
 
             debug("Dealt " + damage + " damage to entity: " + nextTarget);


### PR DESCRIPTION
Some enchantments (specifically the Apotheosis "Telepathy" enchantment) rely on the fake player's position to determine certain logic. 

As the grinder just uses the default FakePlayer without modifying its position, this can result in unexpected interactions, i.e., Apotheosis' "Telepathy" moving item entities spawned by the death of the entity to 0, 0, 0.

I've reported this to Apotheosis so that they can double-check the locations of the fake player versus the entity dying and the item entities, but I figured it also wouldn't hurt to set the position for the fake player.

For reference, I used Industrial Foregoing's Mob Grinder code for how it sets the location of the fake player.

While this was created using the browser edit mode, I've confirmed that it compiles properly.