### PR TITLE
Module Recipe Fixes

### DIFF
--- a/src/main/generated/data/draconicevolution/recipe/modules/item_chaotic_flight.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_chaotic_flight.json
@@ -5,19 +5,9 @@
     "#": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:strong_swiftness"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:potion"
     },

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_draconic_flight.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_draconic_flight.json
@@ -14,19 +14,9 @@
     "C": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:slow_falling"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:potion"
     },

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_draconic_undying.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_draconic_undying.json
@@ -14,19 +14,9 @@
     "C": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:strong_healing"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:potion"
     },

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_draconium_damage.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_draconium_damage.json
@@ -17,19 +17,9 @@
     "P": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:strength"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:potion"
     }

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_draconium_jump.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_draconium_jump.json
@@ -17,19 +17,9 @@
     "P": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:leaping"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:potion"
     }

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_draconium_speed.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_draconium_speed.json
@@ -14,19 +14,9 @@
     "P": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:swiftness"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:potion"
     }

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_damage.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_damage.json
@@ -14,19 +14,9 @@
     "P": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:strong_strength"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:potion"
     }

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_jump.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_jump.json
@@ -14,19 +14,9 @@
     "P": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:strong_leaping"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:potion"
     }

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_night_vision.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_night_vision.json
@@ -14,19 +14,9 @@
     "P": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:night_vision"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:potion"
     }

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_proj_damage.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_proj_damage.json
@@ -17,19 +17,9 @@
     "P": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:strong_strength"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:splash_potion"
     }

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_proj_grav_comp.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_proj_grav_comp.json
@@ -17,19 +17,9 @@
     "P": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:long_slow_falling"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:splash_potion"
     }

--- a/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_proj_velocity.json
+++ b/src/main/generated/data/draconicevolution/recipe/modules/item_wyvern_proj_velocity.json
@@ -17,19 +17,9 @@
     "P": {
       "type": "neoforge:components",
       "components": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": []
-        },
-        "minecraft:enchantments": {
-          "levels": {}
-        },
-        "minecraft:lore": [],
-        "minecraft:max_stack_size": 1,
         "minecraft:potion_contents": {
           "potion": "minecraft:strong_swiftness"
-        },
-        "minecraft:rarity": "common",
-        "minecraft:repair_cost": 0
+        }
       },
       "items": "minecraft:splash_potion"
     }

--- a/src/main/java/com/brandon3055/draconicevolution/datagen/RecipeGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/datagen/RecipeGenerator.java
@@ -1290,7 +1290,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('D', Items.FIREWORK_ROCKET);
 
         shapedRecipe(DEModules.DRACONIC_FLIGHT.get().getItem(), "modules")
-                .patternLine("#C#")
+                .patternLine("#P#")
                 .patternLine("ABA")
                 .patternLine("#D#")
                 .key('#', DETags.Items.INGOTS_DRACONIUM_AWAKENED)
@@ -1300,9 +1300,9 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('D', Items.FIREWORK_ROCKET);
 
         shapedRecipe(DEModules.CHAOTIC_FLIGHT.get().getItem(), "modules")
-                .patternLine("#C#")
+                .patternLine("PCP")
                 .patternLine("ABA")
-                .patternLine("#C#")
+                .patternLine("PCP")
                 .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_SWIFTNESS),Items.POTION))
                 .key('A', DEContent.CORE_AWAKENED)
                 .key('B', DEModules.DRACONIC_FLIGHT.get().getItem())
@@ -1320,7 +1320,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('D', DEModules.WYVERN_SHIELD_CAPACITY.get().getItem());
 
         shapedRecipe(DEModules.DRACONIC_UNDYING.get().getItem(), "modules")
-                .patternLine("#C#")
+                .patternLine("#P#")
                 .patternLine("ABA")
                 .patternLine("#D#")
                 .key('#', DETags.Items.INGOTS_DRACONIUM_AWAKENED)

--- a/src/main/java/com/brandon3055/draconicevolution/datagen/RecipeGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/datagen/RecipeGenerator.java
@@ -1446,7 +1446,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('C', ItemTags.ARROWS)
                 .key('B', DEContent.MODULE_CORE)
                 .key('A', DEContent.CORE_DRACONIUM)
-                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_SWIFTNESS),Items.POTION));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_SWIFTNESS),Items.SPLASH_POTION));
 
         shapedRecipe(DEModules.DRACONIC_PROJ_VELOCITY.get().getItem(), "modules")
                 .patternLine("###")
@@ -1530,7 +1530,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('C', ItemTags.ARROWS)
                 .key('B', DEContent.MODULE_CORE)
                 .key('A', DEContent.CORE_DRACONIUM)
-                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_STRENGTH),Items.POTION));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_STRENGTH),Items.SPLASH_POTION));
 
         shapedRecipe(DEModules.DRACONIC_PROJ_DAMAGE.get().getItem(), "modules")
                 .patternLine("###")
@@ -1558,7 +1558,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('C', ItemTags.ARROWS)
                 .key('B', DEContent.MODULE_CORE)
                 .key('A', DEContent.CORE_DRACONIUM)
-                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.LONG_SLOW_FALLING),Items.POTION));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.LONG_SLOW_FALLING),Items.SPLASH_POTION));
 
         shapedRecipe(DEModules.DRACONIC_PROJ_GRAV_COMP.get().getItem(), "modules")
                 .patternLine("###")

--- a/src/main/java/com/brandon3055/draconicevolution/datagen/RecipeGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/datagen/RecipeGenerator.java
@@ -23,6 +23,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.crafting.DataComponentIngredient;
+import net.minecraft.core.component.DataComponents;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -983,7 +984,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('#', Tags.Items.INGOTS_IRON)
                 .key('A', Items.CLOCK)
                 .key('B', DEContent.MODULE_CORE)
-                .key('P', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.POTION, Potions.SWIFTNESS)));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.SWIFTNESS),Items.POTION));
 
         shapedRecipe(DEModules.WYVERN_SPEED.get().getItem(), "modules")
                 .patternLine("###")
@@ -1016,7 +1017,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .patternLine("ABA")
                 .patternLine("GPI")
                 .key('I', Tags.Items.INGOTS_IRON)
-                .key('P', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.POTION, Potions.STRENGTH)))
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRENGTH),Items.POTION))
                 .key('G', Tags.Items.INGOTS_GOLD)
                 .key('A', Tags.Items.DUSTS_GLOWSTONE)
                 .key('B', DEContent.MODULE_CORE);
@@ -1026,7 +1027,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .patternLine("ABA")
                 .patternLine("IPI")
                 .key('I', DETags.Items.INGOTS_DRACONIUM)
-                .key('P', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.POTION, Potions.STRONG_STRENGTH)))
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_STRENGTH),Items.POTION))
                 .key('A', DEModules.DRACONIUM_DAMAGE.get().getItem())
                 .key('B', DEContent.CORE_DRACONIUM);
 
@@ -1295,14 +1296,14 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('#', DETags.Items.INGOTS_DRACONIUM_AWAKENED)
                 .key('A', DEContent.CORE_WYVERN)
                 .key('B', DEModules.WYVERN_FLIGHT.get().getItem())
-                .key('C', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.POTION, Potions.SLOW_FALLING)))
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.SLOW_FALLING),Items.POTION))
                 .key('D', Items.FIREWORK_ROCKET);
 
         shapedRecipe(DEModules.CHAOTIC_FLIGHT.get().getItem(), "modules")
                 .patternLine("#C#")
                 .patternLine("ABA")
                 .patternLine("#C#")
-                .key('#', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.POTION, Potions.STRONG_SWIFTNESS)))
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_SWIFTNESS),Items.POTION))
                 .key('A', DEContent.CORE_AWAKENED)
                 .key('B', DEModules.DRACONIC_FLIGHT.get().getItem())
                 .key('C', DEContent.CHAOS_FRAG_LARGE);
@@ -1325,7 +1326,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('#', DETags.Items.INGOTS_DRACONIUM_AWAKENED)
                 .key('A', DEContent.CORE_WYVERN)
                 .key('B', DEModules.WYVERN_UNDYING.get().getItem())
-                .key('C', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.POTION, Potions.STRONG_HEALING)))
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_HEALING),Items.POTION))
                 .key('D', DEModules.DRACONIC_SHIELD_CAPACITY.get().getItem());
 
         shapedRecipe(DEModules.CHAOTIC_UNDYING.get().getItem(), "modules")
@@ -1375,7 +1376,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('#', DETags.Items.INGOTS_DRACONIUM)
                 .key('A', DEContent.CORE_DRACONIUM)
                 .key('B', DEContent.MODULE_CORE)
-                .key('P', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.POTION, Potions.NIGHT_VISION)));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.NIGHT_VISION),Items.POTION));
 
         //Jump Boost
         shapedRecipe(DEModules.DRACONIUM_JUMP.get().getItem(), "modules")
@@ -1386,7 +1387,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('B', DEContent.MODULE_CORE)
                 .key('C', Tags.Items.INGOTS_IRON)
                 .key('D', Tags.Items.INGOTS_GOLD)
-                .key('P', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.POTION, Potions.LEAPING)));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.LEAPING),Items.POTION));
 
         shapedRecipe(DEModules.WYVERN_JUMP.get().getItem(), "modules")
                 .patternLine("#P#")
@@ -1395,7 +1396,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('#', DETags.Items.INGOTS_DRACONIUM)
                 .key('B', DEContent.CORE_DRACONIUM)
                 .key('A', DEModules.DRACONIUM_JUMP.get().getItem())
-                .key('P', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.POTION, Potions.STRONG_LEAPING)));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_LEAPING),Items.POTION));
 
         shapedRecipe(DEModules.DRACONIC_JUMP.get().getItem(), "modules")
                 .patternLine("###")
@@ -1445,7 +1446,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('C', ItemTags.ARROWS)
                 .key('B', DEContent.MODULE_CORE)
                 .key('A', DEContent.CORE_DRACONIUM)
-                .key('P', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.SPLASH_POTION, Potions.STRONG_SWIFTNESS)));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_SWIFTNESS),Items.POTION));
 
         shapedRecipe(DEModules.DRACONIC_PROJ_VELOCITY.get().getItem(), "modules")
                 .patternLine("###")
@@ -1529,7 +1530,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('C', ItemTags.ARROWS)
                 .key('B', DEContent.MODULE_CORE)
                 .key('A', DEContent.CORE_DRACONIUM)
-                .key('P', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.SPLASH_POTION, Potions.STRONG_STRENGTH)));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.STRONG_STRENGTH),Items.POTION));
 
         shapedRecipe(DEModules.DRACONIC_PROJ_DAMAGE.get().getItem(), "modules")
                 .patternLine("###")
@@ -1557,7 +1558,7 @@ public class RecipeGenerator extends RecipeProvider {
                 .key('C', ItemTags.ARROWS)
                 .key('B', DEContent.MODULE_CORE)
                 .key('A', DEContent.CORE_DRACONIUM)
-                .key('P', DataComponentIngredient.of(false, PotionContents.createItemStack(Items.SPLASH_POTION, Potions.LONG_SLOW_FALLING)));
+                .key('P', DataComponentIngredient.of(false, DataComponents.POTION_CONTENTS, new PotionContents(Potions.LONG_SLOW_FALLING),Items.POTION));
 
         shapedRecipe(DEModules.DRACONIC_PROJ_GRAV_COMP.get().getItem(), "modules")
                 .patternLine("###")


### PR DESCRIPTION
Fixes issues related to modules that use potions by removing extra unneeded component features from the recipe such as "max stack size", "lore", and "enchantments". The only comparison the recipe should have is the potion effect itself. This fixes #1951 and whatever else may be related to module recipes that use potions.

Also this is my first pull request, hopefully I did it right.

If you need, the datapack I made for this is here (Currently awaiting approval) https://curseforge.com/minecraft/texture-packs/draconic-evolution-recipe-fix