### PR TITLE
Fix overflowCount magnitude off by 2 in large value displays

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/lib/OPStorageOP.java
+++ b/src/main/java/com/brandon3055/draconicevolution/lib/OPStorageOP.java
@@ -281,7 +281,7 @@ public class OPStorageOP implements INBTSerializable<CompoundTag>, IValueHashabl
 
     public Component getReadable() {
         if (overflowCount.compareTo(prefixEnd) > 0) {
-            return Component.literal(decimalFormat.format(overflowCount) + " x (2^64)");
+            return Component.literal(decimalFormat.format(overflowCount.divide(BigInteger.TWO)) + " x (2^64)");
         }
 
         BigInteger value = BigInteger.valueOf(valueStorage).add(overflowCount.multiply(BigInteger.valueOf(Long.MAX_VALUE)));
@@ -318,7 +318,7 @@ public class OPStorageOP implements INBTSerializable<CompoundTag>, IValueHashabl
 
     public String getScientific() {
         if (overflowCount.compareTo(prefixEnd) > 0) {
-            return decimalFormat.format(overflowCount) + " x (2^64) OP";
+            return decimalFormat.format(overflowCount.divide(BigInteger.TWO)) + " x (2^64) OP";
         }
 
         return decimalFormat.format(getStoredBig());

--- a/src/test/java/com/brandon3055/draconicevolution/lib/OPStorageOPTest.java
+++ b/src/test/java/com/brandon3055/draconicevolution/lib/OPStorageOPTest.java
@@ -22,6 +22,15 @@ public class OPStorageOPTest {
     public static final Logger LOGGER = LogManager.getLogger("OPStorageOPTest");
 
     @Test
+    public void testLargeOverflowDisplay() {
+        OPStorageOP storageOP = new OPStorageOP(null, () -> -1L);
+        storageOP.overflowCount = new BigInteger("975781955236953990712502012356953416011859675234");
+        storageOP.valueStorage = 4176350882083897343L;
+        assertEquals("4.87891E47 x (2^64)", storageOP.getReadable().getString());
+        assertEquals("4.87891E47 x (2^64) OP", storageOP.getScientific());
+    }
+
+    @Test
     public void testToString() {
         OPStorageOP storageOP = new OPStorageOP(null, () -> -1L);
 


### PR DESCRIPTION
Fixes #2000

## Problem
When displaying large OP storage values with overflow counts exceeding the prefix threshold, the magnitude was off by a factor of 2. This caused incorrect display of very large numbers in both readable and scientific notation formats.

## Solution
Divide `overflowCount` by 2 when formatting display strings in `getReadable()` and `getScientific()` methods. This corrects the magnitude to match the actual stored value.

## Testing
Added `testLargeOverflowDisplay()` to verify the fix with a large overflow count value, ensuring both readable and scientific formats display correctly.