### PR TITLE
feat: make the max energy core stabilizer distance configurable

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/DEConfig.java
+++ b/src/main/java/com/brandon3055/draconicevolution/DEConfig.java
@@ -85,6 +85,7 @@ public class DEConfig {
 
     public static boolean forceDroppedItemOwner = true;
 
+    public static int energyCoreRange;
     public static Long[] coreCapacity = new Long[]{45500000L, 273000000L, 1640000000L, 9880000000L, 59300000000L, 356000000000L, 2140000000000L, -1L};
 
     private static void loadServer() {
@@ -324,6 +325,12 @@ public class DEConfig {
                         "This may be useful for people like pack developers who want to add custom tool tier progression.")
                 .setDefaultBoolean(false)
                 .onSync((tag, type) -> useToolTierTags = tag.getBoolean());
+
+        serverTag.getValue("energyCoreRange")
+                .syncTagToClient()
+                .setComment("Sets how far energy core stabilizers can be from the energy core")
+                .setDefaultInt(16)
+                .onSync((tag, type) -> energyCoreRange = tag.getInt());
 
         serverTag.getValueList("coreCapacity")
                 .syncTagToClient()

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyCore.java
@@ -56,7 +56,6 @@ public class TileEnergyCore extends TileBCore implements MenuProvider, IInteract
     public static final int MSG_TOGGLE_ACTIVATION = 1;
     public static final int MSG_BUILD_CORE = 2;
     public static final int ADV_STABILIZER_TIER = 5;
-    public static final int MAX_STABILIZER_DIST = 16;
 
     public static final int DEFAULT_FRAME_COLOUR = 0x191919;
     public static final int DEFAULT_TRIANGLE_COLOUR = 0x660099;
@@ -86,6 +85,7 @@ public class TileEnergyCore extends TileBCore implements MenuProvider, IInteract
     public final ManagedUUID linkUUID = register(new ManagedUUID("link_uuid", (UUID) null, SAVE_NBT));
 
     public OPStorageOP energy = new OPStorageOP(this, this::getCapacity);
+    public static int maxStabilizerDist = DEConfig.energyCoreRange;
 
     private MultiBlockDefinition definitionCache = null;
     private MultiBlockBuilder activeBuilder = null;
@@ -355,7 +355,7 @@ public class TileEnergyCore extends TileBCore implements MenuProvider, IInteract
                 //For each of the 4 possible directions around the axis
                 for (int fIndex = 0; fIndex < dirs.length; fIndex++) {
                     Direction facing = dirs[fIndex];
-                    for (int dist = 1; dist < MAX_STABILIZER_DIST; dist++) {
+                    for (int dist = 1; dist < maxStabilizerDist; dist++) {
                         BlockPos testPos = worldPosition.offset(facing.getStepX() * dist, facing.getStepY() * dist, facing.getStepZ() * dist);
                         BlockEntity tile = level.getBlockEntity(testPos);
                         if (!(tile instanceof TileEnergyCoreStabilizer stabilizer)) {

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyCore.java
@@ -253,6 +253,9 @@ public class TileEnergyCore extends TileBCore implements MenuProvider, IInteract
 
         active.set(false);
         updateStabilizers(false);
+
+        stabilizersValid.set(false);
+        validateStructure();
     }
 
     /**

--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyCoreStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileEnergyCoreStabilizer.java
@@ -12,6 +12,7 @@ import com.brandon3055.brandonscore.lib.datamanager.ManagedBool;
 import com.brandon3055.brandonscore.lib.datamanager.ManagedEnum;
 import com.brandon3055.brandonscore.lib.datamanager.ManagedPos;
 import com.brandon3055.brandonscore.utils.FacingUtils;
+import com.brandon3055.draconicevolution.DEConfig;
 import com.brandon3055.draconicevolution.blocks.StructureBlock;
 import com.brandon3055.draconicevolution.blocks.machines.EnergyCoreStabilizer;
 import com.brandon3055.draconicevolution.client.DEParticles;
@@ -223,7 +224,7 @@ public class TileEnergyCoreStabilizer extends TileBCore implements IInteractTile
 
         //Otherwise look for a valid inactive core.
         for (Direction facing : Direction.values()) {
-            for (int i = 0; i < 16; i++) {
+            for (int i = 0; i < DEConfig.energyCoreRange; i++) {
                 BlockEntity tile = level.getBlockEntity(worldPosition.offset(facing.getStepX() * i, facing.getStepY() * i, facing.getStepZ() * i));
                 if (tile instanceof TileEnergyCore) {
                     TileEnergyCore core = (TileEnergyCore) tile;


### PR DESCRIPTION
## What
Adds a config option to change the maximum range stabilizers can be from the energy core. Defaults to 16 (as is the current normal).

## Why
This change was created as the walls of my new energy core room are ~20 blocks away from the core and I couldn't get floating stabilizers to look good in the build.

## ~~Known Issue~~ Fixed
~~Changing max distance after creating an existing energy core requires placing the stabilizer again to update the valid distance, otherwise, the existing stabilizer remains valid (basically only matters if shrinking the distance and you already have a core).~~
Now validates the structure (thus stabilizers) upon deactivation.

## Note
I wasn't sure if placing the option into a new category with the other energy core option would cause existing configs to break, so I just added it above the existing core option, without creating a category.

## Example with limit around 40 blocks:
<img width="768" height="576" alt="2026-03-16_23 40 22-small" src="https://github.com/user-attachments/assets/4ab8ca85-e8d0-49a5-9873-7302acbaf3b2" />