### PR TITLE
[1.20] Fix: overworld ore generation

### DIFF
--- a/src/main/resources/data/draconicevolution/worldgen/configured_feature/overworld_draconium_ore.json
+++ b/src/main/resources/data/draconicevolution/worldgen/configured_feature/overworld_draconium_ore.json
@@ -1,25 +1,25 @@
 {
   "type": "minecraft:ore",
   "config": {
+    "discard_chance_on_air_exposure": 1,
     "size": 8,
-    "discard_chance_on_air_exposure": 0,
     "targets": [
       {
+        "state": {
+          "Name": "draconicevolution:overworld_draconium_ore"
+        },
         "target": {
           "predicate_type": "minecraft:tag_match",
           "tag": "minecraft:stone_ore_replaceables"
-        },
-        "state": {
-          "Name": "draconicevolution:overworld_draconium_ore"
         }
       },
       {
+        "state": {
+          "Name": "draconicevolution:deepslate_draconium_ore"
+        },
         "target": {
           "predicate_type": "minecraft:tag_match",
           "tag": "minecraft:deepslate_ore_replaceables"
-        },
-        "state": {
-          "Name": "draconicevolution:deepslate_draconium_ore"
         }
       }
     ]

--- a/src/main/resources/data/draconicevolution/worldgen/placed_feature/overworld_draconium_ore.json
+++ b/src/main/resources/data/draconicevolution/worldgen/placed_feature/overworld_draconium_ore.json
@@ -2,8 +2,8 @@
   "feature": "draconicevolution:overworld_draconium_ore",
   "placement": [
     {
-      "type": "minecraft:rarity_filter",
-      "chance": 10
+      "type": "minecraft:count",
+      "count": 16
     },
     {
       "type": "minecraft:in_square"
@@ -11,12 +11,12 @@
     {
       "type": "minecraft:height_range",
       "height": {
-        "type": "minecraft:uniform",
-        "min_inclusive": {
-          "absolute": -64
-        },
+        "type": "minecraft:trapezoid",
         "max_inclusive": {
-          "absolute": -48
+          "above_bottom": 16
+        },
+        "min_inclusive": {
+          "above_bottom": -64
         }
       }
     },


### PR DESCRIPTION
Previously, in version 1.20, Draconium Ore was very rare in the overworld. Sometimes it was 4 blocks of ore per 32 chunks, but usually there was no ore at all for 32 chunks or even more. Therefore, it was almost impossible to mine Draconium Ore in the overworld.
After the fix, Draconium Ore appears at an altitude of -64 to -54. It has the same spawn rate as regular Diamond Ore. But instead of diamonds, Draconium Ore appears about three times less often than Diamond per chunk. Therefore, Draconium Ore is still quite rare, but it is impossible to mine.
