### PR TITLE
Make sure mobs get killed if their health is zero or negative

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileGrinder.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/TileGrinder.java
@@ -242,6 +242,9 @@ public class TileGrinder extends TileBCore implements IRSSwitchable, MenuProvide
             }
 
             debug("Dealt " + damage + " damage to entity: " + nextTarget);
+            if (nextTarget.getHealth() <= 0){
+                nextTarget.kill();
+            }
             nextTarget = null;
             opStorage.modifyEnergyStored(-cost);
             return true;


### PR DESCRIPTION
In All The Mons mod pack the mob grinder causes mobs to have a negative or empty health value and that makes them impossible to kill (they take no damage).
Its a simple check if the health <= 0 manually trigger kill on the mob to make sure its dead.